### PR TITLE
[TECH SUPPORT] LPS-32660 Day of Week text on Summary tab incorrect in Calendar Portlet

### DIFF
--- a/portal-web/docroot/html/portlet/calendar/summary.jspf
+++ b/portal-web/docroot/html/portlet/calendar/summary.jspf
@@ -40,7 +40,7 @@ for (int i = 1; i <= maxDayOfMonth; i++) {
 		<td class="lfr-top" style="padding-right: 10px;" width="1%">
 			<div class="calendar-container float-container">
 				<div class="calendar-day">
-					 <div class="day-text"><%= DateUtil.getDate(Time.getDate(selCal), "EEEE", locale, timeZone) %></div>
+					 <div class="day-text"><%= DateUtil.getDate(selCal.getTime(), "EEEE", locale, timeZone) %></div>
 					 <div class="day-number"><%= selDay %></div>
 				</div>
 


### PR DESCRIPTION
Hey Tamás,

Please review my changes.
Root cause: /portal-trunk/portal-web/docroot/html/portlet/calendar/summary.jspf contains the following code to calculate the Day of Week text: <div class="day-text"><%= DateUtil.getDate(Time.getDate(selCal), "EEEE", locale, timeZone) %></div>
Time.getDate adjusts the date which causes the mismatch.

Resolution: Change Time.getDate(selCal) to selCal.getTime().

Thank you,
Ákos
