### PR TITLE
[TECHNICAL-SUPPORT] LPS-32718 Document Library - Add Document button does not check VIEW permisison for a given DLFileEntryType before displaying it

### DIFF
--- a/portal-web/docroot/html/portlet/document_library/add_button.jsp
+++ b/portal-web/docroot/html/portlet/document_library/add_button.jsp
@@ -92,6 +92,9 @@ if ((folder == null) || folder.isSupportsMetadata()) {
 
 			<%
 			for (DLFileEntryType fileEntryType : fileEntryTypes) {
+				if ((fileEntryType.getFileEntryTypeId() > 0) && !DLFileEntryTypePermission.contains(permissionChecker, fileEntryType, ActionKeys.VIEW)) {
+					continue;
+				}
 			%>
 
 				<portlet:renderURL var="addFileEntryTypeURL">


### PR DESCRIPTION
Hey Tamás,

See the complete description at http://issues.liferay.com/browse/LPS-32718

The pattern for the newly added "if-condition" comes from DLFileEntryAssetRendererFactory.getURLAdd() method (line 138):

// ...

if ((classTypeId > 0) &&
    !DLFileEntryTypePermission.contains(
        themeDisplay.getPermissionChecker(), classTypeId,
        ActionKeys.VIEW)) {

```
return null;
```

}

Here, the test for zero ensures that Basic Document DLFileEntryType always be displayed. The classTypeId is the fileEntryTypeId of the given DLFileEntryType. I have tried to apply this logic in add_button.jsp.

Plus, you also can see that if fileEntryTypes is empty, we display the url to add a Basic Document.

After this modification, a user can upload a document to a folder with a specific docType, only if his/her Role has VIEW permission on this DLFileEntryType.

Now, if you define a docType restriction for a folder, a user is able to upload files with types without having permission to see this type at all.

Please, review my changes.

Thanks,
Tibor
