### PR TITLE
[TECHNICAL SUPPORT] LPS-32726

### DIFF
--- a/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/props.ftl
+++ b/portal-impl/src/com/liferay/portal/tools/servicebuilder/dependencies/props.ftl
@@ -13,7 +13,7 @@
 ##
 
     build.namespace=${portletShortName}
-    build.number=${buildNumber}
+    build.number=${buildNumber?c}
     build.date=${currentTimeMillis?c}
     build.auto.upgrade=true
 


### PR DESCRIPTION
Hi,

If build.number > =1000 in the service.properties file, a thousand separator is also included, which causes undesirable behaviour in some rare cases.

By using the "C" built-in function of FreeMaker formatting can be avoided.

For more into: http://freemarker.sourceforge.net/docs/ref_builtins_number.html#ref_builtin_c

Cheers,
Laci.
