### PR TITLE
[TECHNICAL-SUPPORT] LPS-33282 Page sorting in navigation has no permanent effect without UPDATE permission

### DIFF
--- a/portal-web/docroot/html/common/themes/bottom_js.jspf
+++ b/portal-web/docroot/html/common/themes/bottom_js.jspf
@@ -123,7 +123,7 @@ if (layout != null) {
 							for (int i = 0; (layouts != null) && (i < layouts.size()); i++) {
 								Layout curLayout = (Layout)layouts.get(i);
 
-								boolean updateable = SitesUtil.isLayoutUpdateable(curLayout);
+								boolean updateable = SitesUtil.isLayoutUpdateable(curLayout) && LayoutPermissionUtil.contains(themeDisplay.getPermissionChecker(), curLayout, ActionKeys.UPDATE);
 								boolean deleteable = updateable && LayoutPermissionUtil.contains(themeDisplay.getPermissionChecker(), curLayout, ActionKeys.DELETE);
 							%>
 


### PR DESCRIPTION
Hi Tamás,

These variables ("updateable", "deleteable") are used in navigation.js (check method "initializer" from line 87).

If "updateable" is set to "true", drag&drop sorting can be performed on client-side, however, it won't have any effect, since this action requires UPDATE perm. (LayoutServiceImpl.updateLayout())

Please, review my changes.

Thanks,
Tibor
