### PR TITLE
[TECHNICAL-SUPPORT] LPS-31857 Site Pages portlet and Manage Page pop-up allow permission overriding via drag-n-drop

### DIFF
--- a/portal-impl/src/com/liferay/portlet/layoutsadmin/util/LayoutsTreeUtil.java
+++ b/portal-impl/src/com/liferay/portlet/layoutsadmin/util/LayoutsTreeUtil.java
@@ -15,8 +15,6 @@
 package com.liferay.portlet.layoutsadmin.util;
 
 import com.liferay.portal.kernel.dao.orm.QueryUtil;
-import com.liferay.portal.kernel.exception.PortalException;
-import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.json.JSONArray;
 import com.liferay.portal.kernel.json.JSONFactoryUtil;
 import com.liferay.portal.kernel.json.JSONObject;
@@ -34,11 +32,10 @@ import com.liferay.portal.model.LayoutSetBranch;
 import com.liferay.portal.model.User;
 import com.liferay.portal.model.impl.VirtualLayout;
 import com.liferay.portal.security.permission.ActionKeys;
-import com.liferay.portal.security.permission.PermissionChecker;
 import com.liferay.portal.service.LayoutLocalServiceUtil;
 import com.liferay.portal.service.LayoutServiceUtil;
 import com.liferay.portal.service.LayoutSetBranchLocalServiceUtil;
-import com.liferay.portal.service.permission.LayoutPermissionUtil;
+import com.liferay.portal.service.permission.GroupPermissionUtil;
 import com.liferay.portal.theme.ThemeDisplay;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.portal.util.SessionClicks;
@@ -112,6 +109,10 @@ public class LayoutsTreeUtil {
 			end = Math.max(start, Math.min(end, layouts.size()));
 		}
 
+		boolean hasManageLayoutsPermission = GroupPermissionUtil.contains(
+			themeDisplay.getPermissionChecker(), groupId,
+			ActionKeys.MANAGE_LAYOUTS);
+
 		for (Layout layout : layouts.subList(start, end)) {
 			JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
 
@@ -161,9 +162,8 @@ public class LayoutsTreeUtil {
 			jsonObject.put("privateLayout", layout.isPrivateLayout());
 			jsonObject.put("type", layout.getType());
 			jsonObject.put(
-				"updateable",
-				SitesUtil.isLayoutUpdateable(layout) &&
-					checkPermission(themeDisplay, layout));
+				"updateable", hasManageLayoutsPermission &&
+					SitesUtil.isLayoutUpdateable(layout));
 
 			jsonObject.put("uuid", layout.getUuid());
 
@@ -240,17 +240,6 @@ public class LayoutsTreeUtil {
 			paginationJSON);
 
 		return paginationJSONObject.getInt(String.valueOf(layoutId), 0);
-	}
-
-	private static boolean checkPermission(
-			ThemeDisplay themeDisplay, Layout layout)
-		throws PortalException, SystemException {
-	
-		PermissionChecker permissionChecker =
-			themeDisplay.getPermissionChecker();
-	
-		return LayoutPermissionUtil.contains(
-			permissionChecker, layout, ActionKeys.UPDATE);
 	}
 
 }

--- a/portal-web/docroot/html/portlet/layouts_admin/tree_js.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/tree_js.jsp
@@ -28,7 +28,7 @@ boolean checkContentDisplayPage = ParamUtil.getBoolean(request, "checkContentDis
 boolean defaultStateChecked = ParamUtil.getBoolean(request, "defaultStateChecked", false);
 boolean draggableTree = ParamUtil.getBoolean(request, "draggableTree", true);
 boolean expandFirstNode = ParamUtil.getBoolean(request, "expandFirstNode", true);
-boolean hasSiteUpdatePermission = GroupPermissionUtil.contains(permissionChecker, group.getGroupId(), ActionKeys.UPDATE);
+boolean hasManageLayoutsPermission = GroupPermissionUtil.contains(permissionChecker, group.getGroupId(), ActionKeys.MANAGE_LAYOUTS);
 boolean saveState = ParamUtil.getBoolean(request, "saveState", true);
 boolean selectableTree = ParamUtil.getBoolean(request, "selectableTree");
 
@@ -482,13 +482,12 @@ if (!selectableTree) {
 					var dragNode = drag.get('node').get('parentNode');
 					var dropTreeNode = dropNode.getData('tree-node');
 
-					var hasSiteUpdatePermission = <%= hasSiteUpdatePermission %>;
+					var hasManageLayoutsPermission = <%= hasManageLayoutsPermission %>;
 
-					var draggableDropParent =
-						dropTreeNode.get('parentNode').get('draggable');
+					var draggableDropParent = dropTreeNode.get('draggable');
 
 					if (dropTreeNode.get('parentNode').get('id') === rootId) {
-						draggableDropParent = (hasSiteUpdatePermission || draggableDropParent);
+						draggableDropParent = (hasManageLayoutsPermission || draggableDropParent);
 					}
 
 					instance._resetState(instance.nodeContent);


### PR DESCRIPTION
Hey Tamás,

LPS-31857 and LPS-33282 have been created to fix the same issue in navigation, and in Site Pages (and Manage page) portlets.

As we have agreed, I'm checking MANAGE_LAYOUTS permission to enable or disalbe page drag&drop.
I've just modified @zsagia's previous commits according to this requirement.

I'm sending another pull for LPS-33282.

Regards,
Tibor
