### PR TITLE
[TECHNICAL-SUPPORT] LPS-31857 Site Pages portlet and Manage Page pop-up allow permission overriding via drag-n-drop

### DIFF
--- a/portal-impl/src/com/liferay/portlet/layoutsadmin/util/LayoutsTreeUtil.java
+++ b/portal-impl/src/com/liferay/portlet/layoutsadmin/util/LayoutsTreeUtil.java
@@ -31,9 +31,11 @@ import com.liferay.portal.model.LayoutRevision;
 import com.liferay.portal.model.LayoutSetBranch;
 import com.liferay.portal.model.User;
 import com.liferay.portal.model.impl.VirtualLayout;
+import com.liferay.portal.security.permission.ActionKeys;
 import com.liferay.portal.service.LayoutLocalServiceUtil;
 import com.liferay.portal.service.LayoutServiceUtil;
 import com.liferay.portal.service.LayoutSetBranchLocalServiceUtil;
+import com.liferay.portal.service.permission.GroupPermissionUtil;
 import com.liferay.portal.theme.ThemeDisplay;
 import com.liferay.portal.util.PropsValues;
 import com.liferay.portal.util.SessionClicks;
@@ -107,6 +109,10 @@ public class LayoutsTreeUtil {
 			end = Math.max(start, Math.min(end, layouts.size()));
 		}
 
+		boolean hasManageLayoutsPermission = GroupPermissionUtil.contains(
+			themeDisplay.getPermissionChecker(), groupId,
+			ActionKeys.MANAGE_LAYOUTS);
+
 		for (Layout layout : layouts.subList(start, end)) {
 			JSONObject jsonObject = JSONFactoryUtil.createJSONObject();
 
@@ -155,7 +161,10 @@ public class LayoutsTreeUtil {
 			jsonObject.put("priority", layout.getPriority());
 			jsonObject.put("privateLayout", layout.isPrivateLayout());
 			jsonObject.put("type", layout.getType());
-			jsonObject.put("updateable", SitesUtil.isLayoutUpdateable(layout));
+			jsonObject.put(
+				"updateable", hasManageLayoutsPermission &&
+					SitesUtil.isLayoutUpdateable(layout));
+
 			jsonObject.put("uuid", layout.getUuid());
 
 			LayoutRevision layoutRevision = LayoutStagingUtil.getLayoutRevision(


### PR DESCRIPTION
Hey Tamás,

LPS-31857 and LPS-33282 have been created to fix the same issue in navigation, and in Site Pages (and Manage page) portlets.

As we have agreed, I'm checking MANAGE_LAYOUTS permission to enable or disable page drag&drop.
I've just modified @zsagia's previous commits according to this requirement.

I'm sending another pull for LPS-33282.

Regards,
Tibor
