### PR TITLE
[TECHNICAL-SUPPORT] LPS-33712 Layout Template plugins can not be deactivated

### DIFF
--- a/portal-web/docroot/html/portlet/plugins_admin/layout_templates.jspf
+++ b/portal-web/docroot/html/portlet/plugins_admin/layout_templates.jspf
@@ -64,7 +64,7 @@ for (int i = 0; i < results.size(); i++) {
 	}
 
 	rowURL.setParameter("pluginId", layoutTemplate.getLayoutTemplateId());
-	rowURL.setParameter("pluginType", "layout-template");
+	rowURL.setParameter("pluginType", Plugin.TYPE_LAYOUT_TEMPLATE);
 	rowURL.setParameter("title", layoutTemplate.getName());
 
 	// Name and thumbnail


### PR DESCRIPTION
Hi Tamás,

@brianchandotcom has refactored this constant in https://github.com/liferay/liferay-portal/commit/28e769a890b3cf3b25c3a42f69edf916f28c9dd1

We have to use it as "pluginType" parameter, otherwise the updated PluginSettings won't be used/found, and the default settings will be loaded.

Best,
Tibor
