### PR TITLE
LPS-34085 Oracle's JDBC driver isn't handled well by our build scripts

### DIFF
--- a/build-test-websphere-6.1.xml
+++ b/build-test-websphere-6.1.xml
@@ -33,7 +33,7 @@
 				<copy todir="${tstamp.value}">
 					<fileset
 						dir="${jdbc.drivers.optional.dir}"
-						includes="*.jar"
+						includes="${jdbc.drivers}"
 					/>
 				</copy>
 			</then>

--- a/build-test-websphere-8.0.xml
+++ b/build-test-websphere-8.0.xml
@@ -33,7 +33,7 @@
 				<copy todir="${tstamp.value}">
 					<fileset
 						dir="${jdbc.drivers.optional.dir}"
-						includes="*.jar"
+						includes="${jdbc.drivers}"
 					/>
 				</copy>
 			</then>

--- a/build-test.xml
+++ b/build-test.xml
@@ -2409,14 +2409,14 @@
 				<delete includeemptydirs="true" failonerror="false">
 					<fileset
 						dir="${simple.server.lib.global.dir}"
-						includes="db2*.jar"
+						includes="${jdbc.db2.driver}"
 					/>
 				</delete>
 
 				<copy todir="${todir}">
 						<fileset
 							dir="${jdbc.drivers.optional.dir}/db2/8.1.18"
-							includes="*.jar"
+							includes="${jdbc.db2.driver}"
 					/>
 				</copy>
 			</then>
@@ -2424,14 +2424,14 @@
 				<and>
 					<equals arg1="${db.type}" arg2="mysql" />
 					<not>
-						<available file="${simple.server.lib.global.dir}/mysql.jar" />
+						<available file="${simple.server.lib.global.dir}/${jdbc.mysql.driver}" />
 					</not>
 				</and>
 				<then>
 					<copy todir="${todir}">
 						<fileset
 							dir="${jdbc.drivers.optional.dir}/mysql/5.0.7"
-							includes="*.jar"
+							includes="${jdbc.mysql.driver}"
 						/>
 					</copy>
 				</then>
@@ -2442,14 +2442,14 @@
 					<delete includeemptydirs="true" failonerror="false">
 						<fileset
 							dir="${simple.server.lib.global.dir}"
-							includes="ojdbc*.jar"
+							includes="${jdbc.oracle.driver}"
 						/>
 					</delete>
 
 					<copy todir="${todir}">
 						<fileset
 							dir="${jdbc.drivers.optional.dir}/oracle/10.2.0.1.0"
-							includes="*.jar"
+							includes="${jdbc.oracle.driver}"
 						/>
 					</copy>
 				</then>
@@ -2460,14 +2460,14 @@
 					<delete includeemptydirs="true" failonerror="false">
 						<fileset
 							dir="${simple.server.lib.global.dir}"
-							includes="ojdbc*.jar"
+							includes="${jdbc.oracle.driver}"
 						/>
 					</delete>
 
 					<copy todir="${todir}">
 						<fileset
 							dir="${jdbc.drivers.optional.dir}/oracle/11.2.0.1.0"
-							includes="*.jar"
+							includes="${jdbc.oracle.driver}"
 						/>
 					</copy>
 				</then>

--- a/build.properties
+++ b/build.properties
@@ -43,7 +43,17 @@
 ## JDBC Drivers
 ##
 
-    jdbc.drivers=firebird.jar,hsql.jar,ifxjdbc.jar,ifxjdbcx.jar,interbase.jar,jtds.jar,mysql.jar,ojdbc14.jar,p6spy.jar,postgresql.jar,sap.jar,spy.properties
+    jdbc.db2.driver=db2jcc.jar,db2jcc_license_cu.jar
+    jdbc.firebird.driver=firebird.jar
+    jdbc.hsql.driver=hsql.jar
+    jdbc.interbase.driver=interbase.jar
+    jdbc.jtds.driver=jtds.jar
+    jdbc.mysql.driver=mysql.jar
+    jdbc.oracle.driver=ojdbc6.jar
+    jdbc.p6spy.driver=p6spy.jar,spy.properties
+    jdbc.postgresql.driver=postgresql.jar
+
+    jdbc.drivers=${jdbc.db2.driver},${jdbc.firebird.driver},${jdbc.hsql.driver},${jdbc.interbase.driver},${jdbc.jtds.driver},${jdbc.mysql.driver},${jdbc.oracle.driver},${jdbc.p6spy.driver},${jdbc.postgresql.driver}
 
     #jdbc.drivers.optional.dir=
 

--- a/build.xml
+++ b/build.xml
@@ -216,7 +216,7 @@ ${app.server.tomcat.dir}, then run "ant -buildfile build-dist.xml unzip-tomcat".
 				<copy todir="${app.server.lib.global.dir}">
 					<fileset
 						dir="${jdbc.drivers.optional.dir}"
-						includes="*.jar"
+						includes="${jdbc.drivers}"
 					/>
 				</copy>
 			</then>


### PR DESCRIPTION
Hi Tamás,

This ticket doesn't have to be handled with priority, it's not within the frame of technical support.

I was just annoyed by having to copy Oracle's JDBC drivers manually every time I did an "ant all", thus I fixed it.

There were a few other problems I found:
- Obsolete jars: ifxjdbc.jar,ifxjdbcx.jar -> These are for Informix, but Liferay doesn't work on Informix.
- Jars for DB2 were missing from ${jdbc.drivers}.
- Modified a few build-test*.xml to use the newly defined variables.

Cheers,
Laci.
