### PR TITLE
LPS-34066 rowURL doesn't take you to an edit page, so it makes no sense ...

### DIFF
--- a/portal-web/docroot/html/portlet/users_admin/view_flat_organizations.jspf
+++ b/portal-web/docroot/html/portlet/users_admin/view_flat_organizations.jspf
@@ -79,7 +79,7 @@ if (filterManageableOrganizations) {
 				</liferay-portlet:renderURL>
 
 				<%
-				if (!OrganizationPermissionUtil.contains(permissionChecker, organization.getOrganizationId(), ActionKeys.MANAGE_USERS) && !OrganizationPermissionUtil.contains(permissionChecker, organization.getOrganizationId(), ActionKeys.UPDATE)) {
+				if (!OrganizationPermissionUtil.contains(permissionChecker, organization.getOrganizationId(), ActionKeys.VIEW)) {
 					rowURL = null;
 				}
 				%>


### PR DESCRIPTION
...to check these. However, you need the View permission to see that page
[TECHNICAL-SUPPORT] LPS-34066 Not able to click on the Organization profile even if the user has view permissions for it
