### PR TITLE
LPS-34332 - LPS-30384 incorrectly replaces dialogs' onShow in CKEditor

### DIFF
--- a/portal-web/docroot/html/js/editor/ckeditor_diffs/ckconfig.jsp
+++ b/portal-web/docroot/html/js/editor/ckeditor_diffs/ckconfig.jsp
@@ -147,7 +147,13 @@ CKEDITOR.on(
 	function(event) {
 		var dialogDefinition = event.data.definition;
 
+		var originalOnShow = dialogDefinition.onShow;
+
 		dialogDefinition.onShow = function() {
+			if (typeof originalOnShow != 'undefined') {
+				originalOnShow.apply(this);
+			}
+
 			if (window.top != window.self) {
 				var editorElement = this.getParentEditor().container;
 


### PR DESCRIPTION
[TECHNICAL-SUPPORT] [LPS-34332] LPS-30384 ruins CKEditor dialogs, functions, etc.
