### PR TITLE
LPS-29149 The lost Recent Content portlet (Probably an Asset Publisher with bad configuration

### DIFF
--- a/portal-impl/src/com/liferay/portal/events/AddDefaultLayoutSetPrototypesAction.java
+++ b/portal-impl/src/com/liferay/portal/events/AddDefaultLayoutSetPrototypesAction.java
@@ -176,8 +176,8 @@ public class AddDefaultLayoutSetPrototypesAction extends SimpleAction {
 		preferences = new HashMap<String, String>();
 
 		preferences.put(
-			"portletSetupTitle_" + LocaleUtil.getDefault(), "Recent Content");
-		preferences.put("portletSetupUseCustomTitle", Boolean.TRUE.toString());
+			"portletSetupTitle_" + LocaleUtil.getDefault(), "Asset Publisher");
+		preferences.put("portletSetupUseCustomTitle", Boolean.FALSE.toString());
 
 		updatePortletSetup(layout, portletId, preferences);
 


### PR DESCRIPTION
Changed the portlet title from Recent Content to Asset Publisher, and modified the portletSetupUseCustomTitle from True to False.
