### PR TITLE
[TECHNICAL SUPPORT] LPS-35920 Restrict LanguageServlet file download function to work only for valid languageId and valid language key pairs

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/LanguageServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/LanguageServlet.java
@@ -25,6 +25,7 @@ import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringPool;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.util.PropsValues;
 
 import java.io.IOException;
 
@@ -62,14 +63,65 @@ public class LanguageServlet extends HttpServlet {
 			return;
 		}
 
+		Locale locale = null;
+
+		try {
+			locale = LocaleUtil.fromLanguageId(pathArray[0]);
+
+			if (pathArray[0].indexOf(CharPool.UNDERLINE) > 0) {
+				String[] languageIdParts = StringUtil.split(
+					pathArray[0], CharPool.UNDERLINE);
+
+				String languageCode = languageIdParts[0];
+				String countryCode = languageIdParts[1];
+
+				if (!locale.getLanguage().equals(languageCode) ||
+					!locale.getCountry().equals(countryCode)) {
+
+					_log.error("Invalid language id specified");
+
+					return;
+				}
+			}
+			else {
+				if (!locale.getLanguage().equals(pathArray[0])) {
+					_log.error("Invalid language id specified");
+
+					return;
+				}
+			}
+		}
+		catch (Exception e) {
+			_log.error("Invalid language id specified");
+
+			return;
+		}
+
 		if (pathArray.length == 1) {
 			_log.error("Language key is not specified");
 
 			return;
 		}
 
-		Locale locale = LocaleUtil.fromLanguageId(pathArray[0]);
 		String key = pathArray[1];
+		String localizedKey = key;
+
+		try {
+			localizedKey = LanguageUtil.get(locale, key);
+
+			if (!PropsValues.TRANSLATIONS_DISABLED) {
+				if (localizedKey.equals(key)) {
+					_log.error("Invalid language key specified");
+
+					return;
+				}
+			}
+		}
+		catch (Exception e) {
+			if (_log.isWarnEnabled()) {
+				_log.warn(e, e);
+			}
+		}
 
 		Object[] arguments = null;
 
@@ -83,7 +135,7 @@ public class LanguageServlet extends HttpServlet {
 
 		try {
 			if ((arguments == null) || (arguments.length == 0)) {
-				value = LanguageUtil.get(locale, key);
+				value = localizedKey;
 			}
 			else {
 				value = LanguageUtil.format(locale, key, arguments);


### PR DESCRIPTION
Hi Tamás,

There's a possibility to prepare links to download text as plain text file which seems that the portal hosts that file with that possibly offending or obscene content.

In this PR I limited the resource serving to valid languageId and language key pairs so this servlet will do only it's expected job.
