### PR TITLE
LPS-35986 Placed back the manageAttachments() call for file selections

### DIFF
--- a/portal-web/docroot/html/portlet/blogs/edit_entry.jsp
+++ b/portal-web/docroot/html/portlet/blogs/edit_entry.jsp
@@ -191,7 +191,7 @@ boolean preview = ParamUtil.getBoolean(request, "preview");
 								<aui:fieldset>
 									<aui:input cssClass="lfr-blogs-small-image-type" inlineField="<%= true %>" label="small-image" name="type" type="radio" />
 
-									<aui:input cssClass="lfr-blogs-small-image-value" inlineField="<%= true %>" label="" name="smallFile" type="file" />
+									<aui:input cssClass="lfr-blogs-small-image-value" inlineField="<%= true %>" label="" name="smallFile" onChange='<%= renderResponse.getNamespace() + "manageAttachments();" %>' type="file" />
 								</aui:fieldset>
 							</aui:col>
 						</aui:row>


### PR DESCRIPTION
Hi Tamás,

I found this issue on trunk during investigating an issue. The problem comes from LPS-33740 where the related code part is refactored, but the onChange event handler call is missing, hence the form doesn't have the proper encoding for file submitting and the attachments hidden value is not set, so the backend has no idea about the image attachment.
