### PR TITLE
[TECHNICAL-SUPPORT] LPS-25775 Current user's display language is changing automatically while editing other users

### DIFF
--- a/portal-impl/src/com/liferay/portlet/usersadmin/action/EditUserAction.java
+++ b/portal-impl/src/com/liferay/portlet/usersadmin/action/EditUserAction.java
@@ -698,6 +698,9 @@ public class EditUserAction extends PortletAction {
 					PortletSession.APPLICATION_SCOPE);
 			}
 		}
+		else {
+			oldLanguageId = StringPool.BLANK;
+		}
 
 		String portletId = serviceContext.getPortletId();
 


### PR DESCRIPTION
Hi Tamás,

We should change the display languageId only if the user edits itself. Otherwise, it's an unnecessary & annoying change.
We already have a similar approach for the "oldScreenName" variable in the updateUser method:

```
if (oldScreenName.equals(user.getScreenName())) {
    oldScreenName = StringPool.BLANK;
}
```

This is because the processAction method expects to get null or not null strings and performs further actions based on these values (from line 164).

This branch has a HEAD where I was able to test & reproduce the issue. The edit user functions are broken in the current trunk, but the issue still persists.

Here is a rebased branch: https://github.com/lipusz/liferay-portal/tree/LPS-25775-rebased
