### PR TITLE
LPS-25280 $request Velocity variable is empty in the Asset Publisher's abstracts view

### DIFF
--- a/portal-web/docroot/html/portlet/journal/asset/abstract.jsp
+++ b/portal-web/docroot/html/portlet/journal/asset/abstract.jsp
@@ -21,6 +21,8 @@ AssetRenderer assetRenderer = (AssetRenderer)request.getAttribute(WebKeys.ASSET_
 int abstractLength = (Integer)request.getAttribute(WebKeys.ASSET_PUBLISHER_ABSTRACT_LENGTH);
 String viewURL = (String)request.getAttribute(WebKeys.ASSET_PUBLISHER_VIEW_URL);
 
+String xmlRequest = PortletRequestUtil.toXML(renderRequest, renderResponse);
+
 JournalArticle article = (JournalArticle)request.getAttribute(WebKeys.JOURNAL_ARTICLE);
 JournalArticleResource articleResource = JournalArticleResourceLocalServiceUtil.getArticleResource(article.getResourcePrimKey());
 
@@ -31,7 +33,7 @@ boolean workflowAssetPreview = GetterUtil.getBoolean((Boolean)request.getAttribu
 JournalArticleDisplay articleDisplay = null;
 
 if (!workflowAssetPreview && article.isApproved()) {
-	articleDisplay = JournalContentUtil.getDisplay(articleResource.getGroupId(), articleResource.getArticleId(), null, null, languageId, themeDisplay);
+	articleDisplay = JournalContentUtil.getDisplay(articleResource.getGroupId(), articleResource.getArticleId(), null, null, languageId, themeDisplay, 1, xmlRequest);
 }
 else {
 	articleDisplay = JournalArticleLocalServiceUtil.getArticleDisplay(article, null, null, languageId, 1, null, themeDisplay);


### PR DESCRIPTION
[TECHNICAL SUPPORT] [LPS-25280] $request Velocity variable is empty in the Asset Publisher's abstract view
