### PR TITLE
[TECH SUPPORT] LPS-37335 WorkflowDefinitionLink is not used when staging is enabled

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/WorkflowDefinitionLinkLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/WorkflowDefinitionLinkLocalServiceImpl.java
@@ -136,9 +136,7 @@ public class WorkflowDefinitionLinkLocalServiceImpl
 
 		WorkflowDefinitionLink workflowDefinitionLink = null;
 
-		if (groupId > 0) {
-			groupId = StagingUtil.getLiveGroupId(groupId);
-		}
+		groupId = StagingUtil.getLiveGroupId(groupId);
 
 		workflowDefinitionLink =
 			workflowDefinitionLinkPersistence.fetchByG_C_C_C_T(


### PR DESCRIPTION
Hi Tamás,

Resolution: Added code to make sure the WorkflowDefinitionLink is tied to live group.

Please review my changes.

Thanks,
Ákos
