### PR TITLE
[TECHNICAL-SUPPORT] LPS-37415 Theme - Script CDATA inside <setting> element in liferay-look-and-feel.xml generates NullPointerException

### DIFF
--- a/portal-web/docroot/html/portlet/layouts_admin/look_and_feel_themes.jsp
+++ b/portal-web/docroot/html/portlet/layouts_admin/look_and_feel_themes.jsp
@@ -180,7 +180,7 @@ Map<String, ThemeSetting> configurableSettings = selTheme.getConfigurableSetting
 
 									<c:if test="<%= Validator.isNotNull(themeSetting.getScript()) %>">
 										<aui:script position="inline">
-											<%= StringUtil.replace(themeSetting.getScript(), "[@NAMESPACE@]", renderResponse.getNamespace()) %>
+											<%= StringUtil.replace(themeSetting.getScript(), "[@NAMESPACE@]", portletDisplay.getNamespace()) %>
 										</aui:script>
 									</c:if>
 


### PR DESCRIPTION
Hi Tamás,

Object "renderResponse" remains null in cases when no RENDER_PHASE happened before accessing look_and_feel_themes.jsp, e.g. when you select another page in the tree. This can lead to NullPointerException when there is a script defined in liferay-look-and-feel.xml of the given theme.

Original commit: liferay@30d8c4cb62cc94d6a8398c580f21a7e39b877381 by Ray in http://issues.liferay.com/browse/LPS-20343

Let me know if you've any questions.

Regards,
Tibor
