### PR TITLE
[TECHNICAL-SUPPORT | July 24] LPS-37608 Height of Asset Tags & Categories Selector list should be set to "auto"

### DIFF
--- a/portal-web/docroot/html/css/portal/tag_selector.css
+++ b/portal-web/docroot/html/css/portal/tag_selector.css
@@ -5,7 +5,7 @@
 .lfr-tags-selector-list {
 	border: 0 solid transparent;
 	border-width: 0 1px 1px;
-	height: 265px;
+	height: auto;
 	margin-bottom: 0.5em;
 	overflow: auto;
 }


### PR DESCRIPTION
Hi Tamás,

CSS class ".lfr-tags-selector-list" has a hard-coded value (265px) for height in portal-web/docroot/html/css/portal/tag_selector.css. This should be set to "auto" (See 2nd screenshot)
Since the asset_categories_selector extends asset_tags_selector, this one class has affect on both selector.

Best,
Tibor
