### PR TITLE
LPS-37613 Enabling CAS and calling a specific URL will cause the portal to redirect without checking the redirect parameter

### DIFF
--- a/portal-impl/src/com/liferay/portal/action/LoginAction.java
+++ b/portal-impl/src/com/liferay/portal/action/LoginAction.java
@@ -156,6 +156,8 @@ public class LoginAction extends Action {
 
 		String loginRedirect = ParamUtil.getString(request, "redirect");
 
+		loginRedirect = PortalUtil.escapeRedirect(loginRedirect);
+
 		if (Validator.isNotNull(loginRedirect)) {
 			if (PrefsPropsUtil.getBoolean(
 					themeDisplay.getCompanyId(), PropsKeys.CAS_AUTH_ENABLED,


### PR DESCRIPTION
[TECHNICAL-SUPPORT] [LPS-37613] Enabling CAS and calling a specific URL will cause the portal to redirect without checking the redirect parameter
