### PR TITLE
[TECHNICAL REQUEST] ]LPS-37945 DM - When a folder is removed, it's workflowDefinitionLink is left in the db

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFolderLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/impl/DLFolderLocalServiceImpl.java
@@ -216,6 +216,13 @@ public class DLFolderLocalServiceImpl extends DLFolderLocalServiceBaseImpl {
 			}
 		}
 
+		// Workflow
+
+		workflowDefinitionLinkLocalService.deleteWorkflowDefinitionLink(
+			dlFolder.getCompanyId(), dlFolder.getGroupId(),
+			DLFolder.class.getName(), dlFolder.getFolderId(),
+			DLFileEntryTypeConstants.FILE_ENTRY_TYPE_ID_ALL);
+
 		// Resources
 
 		resourceLocalService.deleteResource(


### PR DESCRIPTION
Based on LPS-35029
