### PR TITLE
[TECHNICAL-SUPPORT | Sept. 25] LPS-40231 Link Portlet URLs to Page' in Asset Publisher is not working properly in GA3

### DIFF
--- a/portal-web/docroot/html/portlet/asset_publisher/display/abstracts.jsp
+++ b/portal-web/docroot/html/portlet/asset_publisher/display/abstracts.jsp
@@ -35,7 +35,7 @@ if (Validator.isNull(title)) {
 	title = assetRenderer.getTitle(locale);
 }
 
-PortletURL viewFullContentURL = liferayPortletResponse.createLiferayPortletURL(plid, portletDisplay.getId(), PortletRequest.RENDER_PHASE, false);
+PortletURL viewFullContentURL = liferayPortletResponse.createLiferayPortletURL(plid, portletDisplay.getId(), PortletRequest.RENDER_PHASE, true);
 
 viewFullContentURL.setParameter("struts_action", "/asset_publisher/view_content");
 viewFullContentURL.setParameter("redirect", currentURL);


### PR DESCRIPTION
Hes Tamás,

This is a regression caused by http://issues.liferay.com/browse/LPS-34885:
- liferay@21de81e8b2c8c8fc79c6baee126f5eec2cac889e
