### PR TITLE
[TECH SUPPORT] LPS-41851 Links to Default Site Private Pages do not work if the user is on a non-default locale

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/filters/i18n/I18nFilter.java
+++ b/portal-impl/src/com/liferay/portal/servlet/filters/i18n/I18nFilter.java
@@ -134,7 +134,10 @@ public class I18nFilter extends BasePortalFilter {
 			int[] groupFriendlyURLIndex = PortalUtil.getGroupFriendlyURLIndex(
 				requestURI);
 
-			if (groupFriendlyURLIndex != null) {
+			if ((groupFriendlyURLIndex != null) &&
+				requestURI.startsWith(
+					PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING)) {
+
 				int x = groupFriendlyURLIndex[0];
 				int y = groupFriendlyURLIndex[1];
 


### PR DESCRIPTION
Hi Tamás,

Resolution: Shorten URL only in case of public servlet mappings.

Please review my changes.

Thanks,
Ákos
