### PR TITLE
[TECHNICAL-SUPPORT] LPS-43075 Validating noSuchEntryRedirect with PortalUtil.escapeRedirect

### DIFF
--- a/portal-impl/src/com/liferay/portal/struts/FindAction.java
+++ b/portal-impl/src/com/liferay/portal/struts/FindAction.java
@@ -148,6 +148,9 @@ public abstract class FindAction extends Action {
 			String noSuchEntryRedirect = ParamUtil.getString(
 				request, "noSuchEntryRedirect");
 
+			noSuchEntryRedirect = PortalUtil.escapeRedirect(
+				noSuchEntryRedirect);
+
 			if (Validator.isNotNull(noSuchEntryRedirect) &&
 				(e instanceof NoSuchLayoutException)) {
 


### PR DESCRIPTION
Hello Tamas,

In order to prevent phishers to redirect users to an untrusted site via Documents and Media portlet, I included a validation check for noSuchEntryRedirect.
Due to this modification, all noSuchEntryRedirect URLs will be checked against the redirect.url.ips.allowed portal property.

Best Regards,
Istvan
