### PR TITLE
[TECHNICAL-SUPPORT] LPS-43709 Asset Category selector's and Asset Category Admin's search ignores the user's display language

### DIFF
--- a/portal-impl/src/com/liferay/portlet/asset/service/http/AssetCategoryServiceHttp.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/http/AssetCategoryServiceHttp.java
@@ -502,6 +502,45 @@ public class AssetCategoryServiceHttp {
 		}
 	}
 
+	public static com.liferay.portal.kernel.json.JSONObject getJSONVocabularyCategoriesByTitle(
+		HttpPrincipal httpPrincipal, long groupId, java.lang.String title,
+		long vocabularyId, int start, int end)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		try {
+			MethodKey methodKey = new MethodKey(AssetCategoryServiceUtil.class,
+					"getJSONVocabularyCategoriesByTitle",
+					_getJSONVocabularyCategoriesByTitleParameterTypes12);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
+					title, vocabularyId, start, end);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
+					throw (com.liferay.portal.kernel.exception.PortalException)e;
+				}
+
+				if (e instanceof com.liferay.portal.kernel.exception.SystemException) {
+					throw (com.liferay.portal.kernel.exception.SystemException)e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return (com.liferay.portal.kernel.json.JSONObject)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
 	public static java.util.List<com.liferay.portlet.asset.model.AssetCategory> getVocabularyCategories(
 		HttpPrincipal httpPrincipal, long vocabularyId, int start, int end,
 		com.liferay.portal.kernel.util.OrderByComparator obc)
@@ -510,7 +549,7 @@ public class AssetCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(AssetCategoryServiceUtil.class,
 					"getVocabularyCategories",
-					_getVocabularyCategoriesParameterTypes12);
+					_getVocabularyCategoriesParameterTypes13);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					vocabularyId, start, end, obc);
@@ -549,7 +588,7 @@ public class AssetCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(AssetCategoryServiceUtil.class,
 					"getVocabularyCategories",
-					_getVocabularyCategoriesParameterTypes13);
+					_getVocabularyCategoriesParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					parentCategoryId, vocabularyId, start, end, obc);
@@ -588,7 +627,7 @@ public class AssetCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(AssetCategoryServiceUtil.class,
 					"getVocabularyCategories",
-					_getVocabularyCategoriesParameterTypes14);
+					_getVocabularyCategoriesParameterTypes15);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					name, vocabularyId, start, end, obc);
@@ -615,13 +654,52 @@ public class AssetCategoryServiceHttp {
 		}
 	}
 
+	public static java.util.List<com.liferay.portlet.asset.model.AssetCategory> getVocabularyCategoriesByTitle(
+		HttpPrincipal httpPrincipal, long groupId, java.lang.String title,
+		long vocabularyId, int start, int end)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		try {
+			MethodKey methodKey = new MethodKey(AssetCategoryServiceUtil.class,
+					"getVocabularyCategoriesByTitle",
+					_getVocabularyCategoriesByTitleParameterTypes16);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
+					title, vocabularyId, start, end);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
+					throw (com.liferay.portal.kernel.exception.PortalException)e;
+				}
+
+				if (e instanceof com.liferay.portal.kernel.exception.SystemException) {
+					throw (com.liferay.portal.kernel.exception.SystemException)e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return (java.util.List<com.liferay.portlet.asset.model.AssetCategory>)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
 	public static int getVocabularyCategoriesCount(
 		HttpPrincipal httpPrincipal, long groupId, long vocabularyId)
 		throws com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(AssetCategoryServiceUtil.class,
 					"getVocabularyCategoriesCount",
-					_getVocabularyCategoriesCountParameterTypes15);
+					_getVocabularyCategoriesCountParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					vocabularyId);
@@ -655,7 +733,7 @@ public class AssetCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(AssetCategoryServiceUtil.class,
 					"getVocabularyCategoriesCount",
-					_getVocabularyCategoriesCountParameterTypes16);
+					_getVocabularyCategoriesCountParameterTypes18);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					name, vocabularyId);
@@ -690,7 +768,7 @@ public class AssetCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(AssetCategoryServiceUtil.class,
 					"getVocabularyCategoriesDisplay",
-					_getVocabularyCategoriesDisplayParameterTypes17);
+					_getVocabularyCategoriesDisplayParameterTypes19);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					vocabularyId, start, end, obc);
@@ -730,7 +808,7 @@ public class AssetCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(AssetCategoryServiceUtil.class,
 					"getVocabularyCategoriesDisplay",
-					_getVocabularyCategoriesDisplayParameterTypes18);
+					_getVocabularyCategoriesDisplayParameterTypes20);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					name, vocabularyId, start, end, obc);
@@ -769,7 +847,7 @@ public class AssetCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(AssetCategoryServiceUtil.class,
 					"getVocabularyRootCategories",
-					_getVocabularyRootCategoriesParameterTypes19);
+					_getVocabularyRootCategoriesParameterTypes21);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					vocabularyId, start, end, obc);
@@ -807,7 +885,7 @@ public class AssetCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(AssetCategoryServiceUtil.class,
 					"getVocabularyRootCategories",
-					_getVocabularyRootCategoriesParameterTypes20);
+					_getVocabularyRootCategoriesParameterTypes22);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					vocabularyId, start, end, obc);
@@ -840,7 +918,7 @@ public class AssetCategoryServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(AssetCategoryServiceUtil.class,
 					"getVocabularyRootCategoriesCount",
-					_getVocabularyRootCategoriesCountParameterTypes21);
+					_getVocabularyRootCategoriesCountParameterTypes23);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					vocabularyId);
@@ -875,7 +953,7 @@ public class AssetCategoryServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(AssetCategoryServiceUtil.class,
-					"moveCategory", _moveCategoryParameterTypes22);
+					"moveCategory", _moveCategoryParameterTypes24);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					categoryId, parentCategoryId, vocabularyId, serviceContext);
@@ -913,7 +991,7 @@ public class AssetCategoryServiceHttp {
 		throws com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(AssetCategoryServiceUtil.class,
-					"search", _searchParameterTypes23);
+					"search", _searchParameterTypes25);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					keywords, vocabularyId, start, end, obc);
@@ -947,7 +1025,7 @@ public class AssetCategoryServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(AssetCategoryServiceUtil.class,
-					"search", _searchParameterTypes24);
+					"search", _searchParameterTypes26);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					name, categoryProperties, start, end);
@@ -985,10 +1063,48 @@ public class AssetCategoryServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(AssetCategoryServiceUtil.class,
-					"search", _searchParameterTypes25);
+					"search", _searchParameterTypes27);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					groupIds, name, vocabularyIds, start, end);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
+					throw (com.liferay.portal.kernel.exception.PortalException)e;
+				}
+
+				if (e instanceof com.liferay.portal.kernel.exception.SystemException) {
+					throw (com.liferay.portal.kernel.exception.SystemException)e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return (com.liferay.portal.kernel.json.JSONArray)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
+	public static com.liferay.portal.kernel.json.JSONArray searchTitle(
+		HttpPrincipal httpPrincipal, long[] groupIds, java.lang.String title,
+		long[] vocabularyIds, int start, int end)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		try {
+			MethodKey methodKey = new MethodKey(AssetCategoryServiceUtil.class,
+					"searchTitle", _searchTitleParameterTypes28);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey,
+					groupIds, title, vocabularyIds, start, end);
 
 			Object returnObj = null;
 
@@ -1026,7 +1142,7 @@ public class AssetCategoryServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(AssetCategoryServiceUtil.class,
-					"updateCategory", _updateCategoryParameterTypes26);
+					"updateCategory", _updateCategoryParameterTypes29);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					categoryId, parentCategoryId, titleMap, descriptionMap,
@@ -1104,61 +1220,73 @@ public class AssetCategoryServiceHttp {
 			long.class, java.lang.String.class, long.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getVocabularyCategoriesParameterTypes12 = new Class[] {
-			long.class, int.class, int.class,
-			com.liferay.portal.kernel.util.OrderByComparator.class
+	private static final Class<?>[] _getJSONVocabularyCategoriesByTitleParameterTypes12 =
+		new Class[] {
+			long.class, java.lang.String.class, long.class, int.class, int.class
 		};
 	private static final Class<?>[] _getVocabularyCategoriesParameterTypes13 = new Class[] {
-			long.class, long.class, int.class, int.class,
+			long.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
 	private static final Class<?>[] _getVocabularyCategoriesParameterTypes14 = new Class[] {
+			long.class, long.class, int.class, int.class,
+			com.liferay.portal.kernel.util.OrderByComparator.class
+		};
+	private static final Class<?>[] _getVocabularyCategoriesParameterTypes15 = new Class[] {
 			long.class, java.lang.String.class, long.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getVocabularyCategoriesCountParameterTypes15 =
+	private static final Class<?>[] _getVocabularyCategoriesByTitleParameterTypes16 =
+		new Class[] {
+			long.class, java.lang.String.class, long.class, int.class, int.class
+		};
+	private static final Class<?>[] _getVocabularyCategoriesCountParameterTypes17 =
 		new Class[] { long.class, long.class };
-	private static final Class<?>[] _getVocabularyCategoriesCountParameterTypes16 =
+	private static final Class<?>[] _getVocabularyCategoriesCountParameterTypes18 =
 		new Class[] { long.class, java.lang.String.class, long.class };
-	private static final Class<?>[] _getVocabularyCategoriesDisplayParameterTypes17 =
+	private static final Class<?>[] _getVocabularyCategoriesDisplayParameterTypes19 =
 		new Class[] {
 			long.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getVocabularyCategoriesDisplayParameterTypes18 =
+	private static final Class<?>[] _getVocabularyCategoriesDisplayParameterTypes20 =
 		new Class[] {
 			long.class, java.lang.String.class, long.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getVocabularyRootCategoriesParameterTypes19 =
+	private static final Class<?>[] _getVocabularyRootCategoriesParameterTypes21 =
 		new Class[] {
 			long.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getVocabularyRootCategoriesParameterTypes20 =
+	private static final Class<?>[] _getVocabularyRootCategoriesParameterTypes22 =
 		new Class[] {
 			long.class, long.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getVocabularyRootCategoriesCountParameterTypes21 =
+	private static final Class<?>[] _getVocabularyRootCategoriesCountParameterTypes23 =
 		new Class[] { long.class, long.class };
-	private static final Class<?>[] _moveCategoryParameterTypes22 = new Class[] {
+	private static final Class<?>[] _moveCategoryParameterTypes24 = new Class[] {
 			long.class, long.class, long.class,
 			com.liferay.portal.service.ServiceContext.class
 		};
-	private static final Class<?>[] _searchParameterTypes23 = new Class[] {
+	private static final Class<?>[] _searchParameterTypes25 = new Class[] {
 			long.class, java.lang.String.class, long.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _searchParameterTypes24 = new Class[] {
+	private static final Class<?>[] _searchParameterTypes26 = new Class[] {
 			long.class, java.lang.String.class, java.lang.String[].class,
 			int.class, int.class
 		};
-	private static final Class<?>[] _searchParameterTypes25 = new Class[] {
+	private static final Class<?>[] _searchParameterTypes27 = new Class[] {
 			long[].class, java.lang.String.class, long[].class, int.class,
 			int.class
 		};
-	private static final Class<?>[] _updateCategoryParameterTypes26 = new Class[] {
+	private static final Class<?>[] _searchTitleParameterTypes28 = new Class[] {
+			long[].class, java.lang.String.class, long[].class, int.class,
+			int.class
+		};
+	private static final Class<?>[] _updateCategoryParameterTypes29 = new Class[] {
 			long.class, long.class, java.util.Map.class, java.util.Map.class,
 			long.class, java.lang.String[].class,
 			com.liferay.portal.service.ServiceContext.class

--- a/portal-impl/src/com/liferay/portlet/asset/service/http/AssetCategoryServiceSoap.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/http/AssetCategoryServiceSoap.java
@@ -289,6 +289,22 @@ public class AssetCategoryServiceSoap {
 		}
 	}
 
+	public static java.lang.String getJSONVocabularyCategoriesByTitle(
+		long groupId, java.lang.String title, long vocabularyId, int start,
+		int end) throws RemoteException {
+		try {
+			com.liferay.portal.kernel.json.JSONObject returnValue = AssetCategoryServiceUtil.getJSONVocabularyCategoriesByTitle(groupId,
+					title, vocabularyId, start, end);
+
+			return returnValue.toString();
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			throw new RemoteException(e.getMessage());
+		}
+	}
+
 	public static com.liferay.portlet.asset.model.AssetCategorySoap[] getVocabularyCategories(
 		long vocabularyId, int start, int end,
 		com.liferay.portal.kernel.util.OrderByComparator obc)
@@ -333,6 +349,23 @@ public class AssetCategoryServiceSoap {
 			java.util.List<com.liferay.portlet.asset.model.AssetCategory> returnValue =
 				AssetCategoryServiceUtil.getVocabularyCategories(groupId, name,
 					vocabularyId, start, end, obc);
+
+			return com.liferay.portlet.asset.model.AssetCategorySoap.toSoapModels(returnValue);
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			throw new RemoteException(e.getMessage());
+		}
+	}
+
+	public static com.liferay.portlet.asset.model.AssetCategorySoap[] getVocabularyCategoriesByTitle(
+		long groupId, java.lang.String title, long vocabularyId, int start,
+		int end) throws RemoteException {
+		try {
+			java.util.List<com.liferay.portlet.asset.model.AssetCategory> returnValue =
+				AssetCategoryServiceUtil.getVocabularyCategoriesByTitle(groupId,
+					title, vocabularyId, start, end);
 
 			return com.liferay.portlet.asset.model.AssetCategorySoap.toSoapModels(returnValue);
 		}
@@ -521,6 +554,22 @@ public class AssetCategoryServiceSoap {
 		try {
 			com.liferay.portal.kernel.json.JSONArray returnValue = AssetCategoryServiceUtil.search(groupIds,
 					name, vocabularyIds, start, end);
+
+			return returnValue.toString();
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			throw new RemoteException(e.getMessage());
+		}
+	}
+
+	public static java.lang.String searchTitle(long[] groupIds,
+		java.lang.String title, long[] vocabularyIds, int start, int end)
+		throws RemoteException {
+		try {
+			com.liferay.portal.kernel.json.JSONArray returnValue = AssetCategoryServiceUtil.searchTitle(groupIds,
+					title, vocabularyIds, start, end);
 
 			return returnValue.toString();
 		}

--- a/portal-impl/src/com/liferay/portlet/asset/service/http/AssetVocabularyServiceHttp.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/http/AssetVocabularyServiceHttp.java
@@ -531,13 +531,52 @@ public class AssetVocabularyServiceHttp {
 		}
 	}
 
+	public static java.util.List<com.liferay.portlet.asset.model.AssetVocabulary> getGroupVocabulariesByTitle(
+		HttpPrincipal httpPrincipal, long groupId, java.lang.String title,
+		int start, int end)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		try {
+			MethodKey methodKey = new MethodKey(AssetVocabularyServiceUtil.class,
+					"getGroupVocabulariesByTitle",
+					_getGroupVocabulariesByTitleParameterTypes13);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
+					title, start, end);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
+					throw (com.liferay.portal.kernel.exception.PortalException)e;
+				}
+
+				if (e instanceof com.liferay.portal.kernel.exception.SystemException) {
+					throw (com.liferay.portal.kernel.exception.SystemException)e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return (java.util.List<com.liferay.portlet.asset.model.AssetVocabulary>)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
 	public static int getGroupVocabulariesCount(HttpPrincipal httpPrincipal,
 		long groupId)
 		throws com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(AssetVocabularyServiceUtil.class,
 					"getGroupVocabulariesCount",
-					_getGroupVocabulariesCountParameterTypes13);
+					_getGroupVocabulariesCountParameterTypes14);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId);
 
@@ -569,7 +608,7 @@ public class AssetVocabularyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(AssetVocabularyServiceUtil.class,
 					"getGroupVocabulariesCount",
-					_getGroupVocabulariesCountParameterTypes14);
+					_getGroupVocabulariesCountParameterTypes15);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					name);
@@ -605,7 +644,7 @@ public class AssetVocabularyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(AssetVocabularyServiceUtil.class,
 					"getGroupVocabulariesDisplay",
-					_getGroupVocabulariesDisplayParameterTypes15);
+					_getGroupVocabulariesDisplayParameterTypes16);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					name, start, end, addDefaultVocabulary, obc);
@@ -644,10 +683,49 @@ public class AssetVocabularyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(AssetVocabularyServiceUtil.class,
 					"getGroupVocabulariesDisplay",
-					_getGroupVocabulariesDisplayParameterTypes16);
+					_getGroupVocabulariesDisplayParameterTypes17);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					name, start, end, obc);
+
+			Object returnObj = null;
+
+			try {
+				returnObj = TunnelUtil.invoke(httpPrincipal, methodHandler);
+			}
+			catch (Exception e) {
+				if (e instanceof com.liferay.portal.kernel.exception.PortalException) {
+					throw (com.liferay.portal.kernel.exception.PortalException)e;
+				}
+
+				if (e instanceof com.liferay.portal.kernel.exception.SystemException) {
+					throw (com.liferay.portal.kernel.exception.SystemException)e;
+				}
+
+				throw new com.liferay.portal.kernel.exception.SystemException(e);
+			}
+
+			return (com.liferay.portlet.asset.model.AssetVocabularyDisplay)returnObj;
+		}
+		catch (com.liferay.portal.kernel.exception.SystemException se) {
+			_log.error(se, se);
+
+			throw se;
+		}
+	}
+
+	public static com.liferay.portlet.asset.model.AssetVocabularyDisplay getGroupVocabulariesDisplayByTitle(
+		HttpPrincipal httpPrincipal, long groupId, java.lang.String title,
+		int start, int end, boolean addDefaultVocabulary)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		try {
+			MethodKey methodKey = new MethodKey(AssetVocabularyServiceUtil.class,
+					"getGroupVocabulariesDisplayByTitle",
+					_getGroupVocabulariesDisplayByTitleParameterTypes18);
+
+			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
+					title, start, end, addDefaultVocabulary);
 
 			Object returnObj = null;
 
@@ -683,7 +761,7 @@ public class AssetVocabularyServiceHttp {
 		try {
 			MethodKey methodKey = new MethodKey(AssetVocabularyServiceUtil.class,
 					"getJSONGroupVocabularies",
-					_getJSONGroupVocabulariesParameterTypes17);
+					_getJSONGroupVocabulariesParameterTypes19);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey, groupId,
 					name, start, end, obc);
@@ -720,7 +798,7 @@ public class AssetVocabularyServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(AssetVocabularyServiceUtil.class,
-					"getVocabularies", _getVocabulariesParameterTypes18);
+					"getVocabularies", _getVocabulariesParameterTypes20);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					vocabularyIds);
@@ -757,7 +835,7 @@ public class AssetVocabularyServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(AssetVocabularyServiceUtil.class,
-					"getVocabulary", _getVocabularyParameterTypes19);
+					"getVocabulary", _getVocabularyParameterTypes21);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					vocabularyId);
@@ -798,7 +876,7 @@ public class AssetVocabularyServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(AssetVocabularyServiceUtil.class,
-					"updateVocabulary", _updateVocabularyParameterTypes20);
+					"updateVocabulary", _updateVocabularyParameterTypes22);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					vocabularyId, titleMap, descriptionMap, settings,
@@ -840,7 +918,7 @@ public class AssetVocabularyServiceHttp {
 			com.liferay.portal.kernel.exception.SystemException {
 		try {
 			MethodKey methodKey = new MethodKey(AssetVocabularyServiceUtil.class,
-					"updateVocabulary", _updateVocabularyParameterTypes21);
+					"updateVocabulary", _updateVocabularyParameterTypes23);
 
 			MethodHandler methodHandler = new MethodHandler(methodKey,
 					vocabularyId, title, titleMap, descriptionMap, settings,
@@ -918,39 +996,46 @@ public class AssetVocabularyServiceHttp {
 			long.class, java.lang.String.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupVocabulariesCountParameterTypes13 = new Class[] {
+	private static final Class<?>[] _getGroupVocabulariesByTitleParameterTypes13 =
+		new Class[] { long.class, java.lang.String.class, int.class, int.class };
+	private static final Class<?>[] _getGroupVocabulariesCountParameterTypes14 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _getGroupVocabulariesCountParameterTypes14 = new Class[] {
+	private static final Class<?>[] _getGroupVocabulariesCountParameterTypes15 = new Class[] {
 			long.class, java.lang.String.class
 		};
-	private static final Class<?>[] _getGroupVocabulariesDisplayParameterTypes15 =
+	private static final Class<?>[] _getGroupVocabulariesDisplayParameterTypes16 =
 		new Class[] {
 			long.class, java.lang.String.class, int.class, int.class,
 			boolean.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getGroupVocabulariesDisplayParameterTypes16 =
+	private static final Class<?>[] _getGroupVocabulariesDisplayParameterTypes17 =
 		new Class[] {
 			long.class, java.lang.String.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getJSONGroupVocabulariesParameterTypes17 = new Class[] {
+	private static final Class<?>[] _getGroupVocabulariesDisplayByTitleParameterTypes18 =
+		new Class[] {
+			long.class, java.lang.String.class, int.class, int.class,
+			boolean.class
+		};
+	private static final Class<?>[] _getJSONGroupVocabulariesParameterTypes19 = new Class[] {
 			long.class, java.lang.String.class, int.class, int.class,
 			com.liferay.portal.kernel.util.OrderByComparator.class
 		};
-	private static final Class<?>[] _getVocabulariesParameterTypes18 = new Class[] {
+	private static final Class<?>[] _getVocabulariesParameterTypes20 = new Class[] {
 			long[].class
 		};
-	private static final Class<?>[] _getVocabularyParameterTypes19 = new Class[] {
+	private static final Class<?>[] _getVocabularyParameterTypes21 = new Class[] {
 			long.class
 		};
-	private static final Class<?>[] _updateVocabularyParameterTypes20 = new Class[] {
+	private static final Class<?>[] _updateVocabularyParameterTypes22 = new Class[] {
 			long.class, java.util.Map.class, java.util.Map.class,
 			java.lang.String.class,
 			com.liferay.portal.service.ServiceContext.class
 		};
-	private static final Class<?>[] _updateVocabularyParameterTypes21 = new Class[] {
+	private static final Class<?>[] _updateVocabularyParameterTypes23 = new Class[] {
 			long.class, java.lang.String.class, java.util.Map.class,
 			java.util.Map.class, java.lang.String.class,
 			com.liferay.portal.service.ServiceContext.class

--- a/portal-impl/src/com/liferay/portlet/asset/service/http/AssetVocabularyServiceSoap.java
+++ b/portal-impl/src/com/liferay/portlet/asset/service/http/AssetVocabularyServiceSoap.java
@@ -302,6 +302,23 @@ public class AssetVocabularyServiceSoap {
 		}
 	}
 
+	public static com.liferay.portlet.asset.model.AssetVocabularySoap[] getGroupVocabulariesByTitle(
+		long groupId, java.lang.String title, int start, int end)
+		throws RemoteException {
+		try {
+			java.util.List<com.liferay.portlet.asset.model.AssetVocabulary> returnValue =
+				AssetVocabularyServiceUtil.getGroupVocabulariesByTitle(groupId,
+					title, start, end);
+
+			return com.liferay.portlet.asset.model.AssetVocabularySoap.toSoapModels(returnValue);
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			throw new RemoteException(e.getMessage());
+		}
+	}
+
 	public static int getGroupVocabulariesCount(long groupId)
 		throws RemoteException {
 		try {
@@ -356,6 +373,22 @@ public class AssetVocabularyServiceSoap {
 		try {
 			com.liferay.portlet.asset.model.AssetVocabularyDisplay returnValue = AssetVocabularyServiceUtil.getGroupVocabulariesDisplay(groupId,
 					name, start, end, obc);
+
+			return returnValue;
+		}
+		catch (Exception e) {
+			_log.error(e, e);
+
+			throw new RemoteException(e.getMessage());
+		}
+	}
+
+	public static com.liferay.portlet.asset.model.AssetVocabularyDisplay getGroupVocabulariesDisplayByTitle(
+		long groupId, java.lang.String title, int start, int end,
+		boolean addDefaultVocabulary) throws RemoteException {
+		try {
+			com.liferay.portlet.asset.model.AssetVocabularyDisplay returnValue = AssetVocabularyServiceUtil.getGroupVocabulariesDisplayByTitle(groupId,
+					title, start, end, addDefaultVocabulary);
 
 			return returnValue;
 		}

--- a/portal-impl/src/com/liferay/portlet/asset/util/AssetCategoryIndexer.java
+++ b/portal-impl/src/com/liferay/portlet/asset/util/AssetCategoryIndexer.java
@@ -1,0 +1,242 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portlet.asset.util;
+
+import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.search.BaseIndexer;
+import com.liferay.portal.kernel.search.BooleanClauseOccur;
+import com.liferay.portal.kernel.search.BooleanQuery;
+import com.liferay.portal.kernel.search.BooleanQueryFactoryUtil;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.DocumentImpl;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.SearchEngineUtil;
+import com.liferay.portal.kernel.search.Summary;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.util.PortletKeys;
+import com.liferay.portlet.asset.model.AssetCategory;
+import com.liferay.portlet.asset.service.AssetCategoryServiceUtil;
+import com.liferay.portlet.asset.service.persistence.AssetCategoryActionableDynamicQuery;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Locale;
+
+import javax.portlet.PortletURL;
+
+/**
+ * @author Istvan Andras Dezsi
+ */
+public class AssetCategoryIndexer extends BaseIndexer {
+
+	public static final String[] CLASS_NAMES = {
+		AssetCategory.class.getName()
+	};
+
+	public static final String PORTLET_ID = PortletKeys.ASSET_CATEGORIES_ADMIN;
+
+	@Override
+	public String[] getClassNames() {
+		return CLASS_NAMES;
+	}
+
+	@Override
+	public String getPortletId() {
+		return PORTLET_ID;
+	}
+
+	@Override
+	public void postProcessSearchQuery(
+			BooleanQuery searchQuery, SearchContext searchContext)
+		throws Exception {
+
+		addSearchEntryClassNames(searchQuery, searchContext);
+		addGroupIdTerm(searchQuery, searchContext, Field.GROUP_ID);
+		addSearchLocalizedTerm(searchQuery, searchContext, Field.TITLE, true);
+		addVocabularyIdsTerm(searchQuery, searchContext, VOCABULARY_ID);
+	}
+
+	protected void addGroupIdTerm(
+			BooleanQuery searchQuery, SearchContext searchContext, String field)
+		throws Exception {
+
+		if (Validator.isNull(field)) {
+			return;
+		}
+
+		long[] groupIds = searchContext.getGroupIds();
+
+		if (Validator.isNull(groupIds)) {
+			return;
+		}
+
+		searchQuery.addRequiredTerm(Field.GROUP_ID, groupIds[0]);
+}
+
+	@Override
+	protected void addSearchLocalizedTerm(
+			BooleanQuery searchQuery, SearchContext searchContext, String field,
+			boolean like)
+		throws Exception {
+
+		if (Validator.isNull(field)) {
+			return;
+		}
+
+		String value = String.valueOf(searchContext.getAttribute(field));
+
+		if (Validator.isNull(value)) {
+			value = searchContext.getKeywords();
+		}
+
+		if (Validator.isNull(value)) {
+			return;
+		}
+
+		String localizedField = DocumentImpl.getLocalizedName(
+			searchContext.getLocale(), field);
+
+		BooleanQuery titleQuery = BooleanQueryFactoryUtil.create(searchContext);
+
+		titleQuery.addTerm(field, value, like);
+		titleQuery.addTerm(localizedField, value, like);
+
+		searchQuery.add(titleQuery, BooleanClauseOccur.MUST);
+	}
+
+	protected void addVocabularyIdsTerm(
+			BooleanQuery searchQuery, SearchContext searchContext, String field)
+		throws Exception {
+
+		if (Validator.isNull(field)) {
+			return;
+		}
+
+		long[] vocabularyIds = (long[])searchContext.getAttribute(
+			"vocabularyIds");
+
+		if (Validator.isNull(vocabularyIds)) {
+			return;
+		}
+
+		BooleanQuery vocabularyQuery = BooleanQueryFactoryUtil.create(
+			searchContext);
+
+		for (long vocabularyId : vocabularyIds) {
+			vocabularyQuery.addTerm(
+				VOCABULARY_ID, String.valueOf(vocabularyId), false);
+		}
+
+		BooleanClauseOccur booleanClauseOccur = BooleanClauseOccur.MUST;
+
+		searchQuery.add(vocabularyQuery, booleanClauseOccur);
+}
+
+	@Override
+	protected void doDelete(Object obj) throws Exception {
+		AssetCategory assetCategory = (AssetCategory)obj;
+		deleteDocument(
+			assetCategory.getCompanyId(), assetCategory.getCategoryId());
+	}
+
+	@Override
+	protected Document doGetDocument(Object obj) throws Exception {
+		AssetCategory assetCategory = (AssetCategory)obj;
+
+		Document document = getBaseModelDocument(PORTLET_ID, assetCategory);
+
+		document.addKeyword(Field.CATEGORY_ID, assetCategory.getCategoryId());
+		document.addText(Field.NAME, assetCategory.getName());
+		document.addLocalizedText(Field.TITLE, assetCategory.getTitleMap());
+		document.addLocalizedText(
+			Field.DESCRIPTION, assetCategory.getDescriptionMap());
+		document.addKeyword(VOCABULARY_ID, assetCategory.getVocabularyId());
+
+		return document;
+	}
+
+	@Override
+	protected Summary doGetSummary(
+			Document document, Locale locale, String snippet,
+				PortletURL portletURL)
+		throws Exception {
+
+		return null;
+	}
+
+	@Override
+	protected void doReindex(Object obj) throws Exception {
+		AssetCategory assetCategory = (AssetCategory)obj;
+
+		Document document = getDocument(assetCategory);
+
+		SearchEngineUtil.updateDocument(
+			getSearchEngineId(), assetCategory.getCompanyId(), document);
+	}
+
+	@Override
+	protected void doReindex(String className, long classPK) throws Exception {
+		AssetCategory assetCategory = AssetCategoryServiceUtil.getCategory(
+			classPK);
+
+		doReindex(assetCategory);
+	}
+
+	@Override
+	protected void doReindex(String[] ids) throws Exception {
+		long companyId = GetterUtil.getLong(ids[0]);
+
+		reindexAssetCategories(companyId);
+	}
+
+	@Override
+	protected String getPortletId(SearchContext searchContext) {
+		return PORTLET_ID;
+	}
+
+	protected void reindexAssetCategories(long companyId)
+		throws PortalException, SystemException {
+
+		final Collection<Document> documents = new ArrayList<Document>();
+
+		ActionableDynamicQuery actionalbleDynamicQuery =
+			new AssetCategoryActionableDynamicQuery() {
+
+				@Override
+				protected void performAction(Object object)
+					throws PortalException, SystemException {
+
+					AssetCategory assetCategory = (AssetCategory)object;
+
+					Document document = getDocument(assetCategory);
+					documents.add(document);
+				}
+			};
+
+		actionalbleDynamicQuery.setCompanyId(companyId);
+
+		actionalbleDynamicQuery.performActions();
+
+		SearchEngineUtil.updateDocuments(
+			getSearchEngineId(), companyId, documents);
+	}
+
+	private static final String VOCABULARY_ID = "vocabularyId";
+
+}

--- a/portal-impl/src/com/liferay/portlet/asset/util/AssetVocabularyIndexer.java
+++ b/portal-impl/src/com/liferay/portlet/asset/util/AssetVocabularyIndexer.java
@@ -1,0 +1,213 @@
+/**
+ * Copyright (c) 2000-2013 Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.portlet.asset.util;
+
+import com.liferay.portal.kernel.dao.orm.ActionableDynamicQuery;
+import com.liferay.portal.kernel.exception.PortalException;
+import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.search.BaseIndexer;
+import com.liferay.portal.kernel.search.BooleanClauseOccur;
+import com.liferay.portal.kernel.search.BooleanQuery;
+import com.liferay.portal.kernel.search.BooleanQueryFactoryUtil;
+import com.liferay.portal.kernel.search.Document;
+import com.liferay.portal.kernel.search.DocumentImpl;
+import com.liferay.portal.kernel.search.Field;
+import com.liferay.portal.kernel.search.SearchContext;
+import com.liferay.portal.kernel.search.SearchEngineUtil;
+import com.liferay.portal.kernel.search.Summary;
+import com.liferay.portal.kernel.util.GetterUtil;
+import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.util.PortletKeys;
+import com.liferay.portlet.asset.model.AssetVocabulary;
+import com.liferay.portlet.asset.service.AssetVocabularyServiceUtil;
+import com.liferay.portlet.asset.service.persistence.AssetVocabularyActionableDynamicQuery;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Locale;
+
+import javax.portlet.PortletURL;
+
+/**
+ * @author Istvan Andras Dezsi
+ */
+public class AssetVocabularyIndexer extends BaseIndexer {
+
+	public static final String[] CLASS_NAMES = {
+		AssetVocabulary.class.getName()
+	};
+
+	public static final String PORTLET_ID = PortletKeys.ASSET_CATEGORIES_ADMIN;
+
+	@Override
+	public String[] getClassNames() {
+		return CLASS_NAMES;
+	}
+
+	@Override
+	public String getPortletId() {
+		return PORTLET_ID;
+	}
+
+	@Override
+	public void postProcessSearchQuery(
+			BooleanQuery searchQuery, SearchContext searchContext)
+		throws Exception {
+
+		addSearchEntryClassNames(searchQuery, searchContext);
+		addGroupIdTerm(searchQuery, searchContext, Field.GROUP_ID);
+		addSearchLocalizedTerm(searchQuery, searchContext, Field.TITLE, true);
+	}
+
+	protected void addGroupIdTerm(
+		BooleanQuery searchQuery, SearchContext searchContext, String field)
+	throws Exception {
+
+	if (Validator.isNull(field)) {
+		return;
+	}
+
+	long[] groupIds = searchContext.getGroupIds();
+
+	if (Validator.isNull(groupIds)) {
+		return;
+	}
+
+	searchQuery.addRequiredTerm(Field.GROUP_ID, groupIds[0]);
+}
+
+	@Override
+	protected void addSearchLocalizedTerm(
+			BooleanQuery searchQuery, SearchContext searchContext, String field,
+			boolean like)
+		throws Exception {
+
+		if (Validator.isNull(field)) {
+			return;
+		}
+
+		String value = String.valueOf(searchContext.getAttribute(field));
+
+		if (Validator.isNull(value)) {
+			value = searchContext.getKeywords();
+		}
+
+		if (Validator.isNull(value)) {
+			return;
+		}
+
+		String localizedField = DocumentImpl.getLocalizedName(
+			searchContext.getLocale(), field);
+
+		BooleanQuery titleQuery = BooleanQueryFactoryUtil.create(searchContext);
+
+		titleQuery.addTerm(field, value, like);
+		titleQuery.addTerm(localizedField, value, like);
+
+		searchQuery.add(titleQuery, BooleanClauseOccur.MUST);
+	}
+
+	@Override
+	protected void doDelete(Object obj) throws Exception {
+		AssetVocabulary assetVocabulary = (AssetVocabulary)obj;
+		deleteDocument(
+			assetVocabulary.getCompanyId(), assetVocabulary.getVocabularyId());
+	}
+
+	@Override
+	protected Document doGetDocument(Object obj) throws Exception {
+		AssetVocabulary assetVocabulary = (AssetVocabulary)obj;
+
+		Document document = getBaseModelDocument(PORTLET_ID, assetVocabulary);
+
+		document.addKeyword(VOCABULARY_ID, assetVocabulary.getVocabularyId());
+		document.addText(Field.NAME, assetVocabulary.getName());
+		document.addLocalizedText(Field.TITLE, assetVocabulary.getTitleMap());
+		document.addLocalizedText(
+			Field.DESCRIPTION, assetVocabulary.getDescriptionMap());
+
+		return document;
+	}
+
+	@Override
+	protected Summary doGetSummary(
+			Document document, Locale locale, String snippet,
+				PortletURL portletURL)
+		throws Exception {
+
+		return null;
+	}
+
+	@Override
+	protected void doReindex(Object obj) throws Exception {
+		AssetVocabulary assetVocabulary = (AssetVocabulary)obj;
+
+		Document document = getDocument(assetVocabulary);
+
+		SearchEngineUtil.updateDocument(
+			getSearchEngineId(), assetVocabulary.getCompanyId(), document);
+	}
+
+	@Override
+	protected void doReindex(String className, long classPK) throws Exception {
+		AssetVocabulary assetVocabulary =
+						AssetVocabularyServiceUtil.getVocabulary(classPK);
+
+		doReindex(assetVocabulary);
+	}
+
+	@Override
+	protected void doReindex(String[] ids) throws Exception {
+		long companyId = GetterUtil.getLong(ids[0]);
+
+		reindexAssetVocabularies(companyId);
+	}
+
+	@Override
+	protected String getPortletId(SearchContext searchContext) {
+
+		return PORTLET_ID;
+	}
+
+	protected void reindexAssetVocabularies(long companyId)
+		throws PortalException, SystemException {
+
+		final Collection<Document> documents = new ArrayList<Document>();
+
+		ActionableDynamicQuery actionalbleDynamicQuery =
+			new AssetVocabularyActionableDynamicQuery() {
+
+				@Override
+				protected void performAction(Object object)
+					throws PortalException, SystemException {
+
+					AssetVocabulary assetVocabulary = (AssetVocabulary)object;
+
+					Document document = getDocument(assetVocabulary);
+					documents.add(document);
+				}
+			};
+
+		actionalbleDynamicQuery.setCompanyId(companyId);
+
+		actionalbleDynamicQuery.performActions();
+
+		SearchEngineUtil.updateDocuments(
+			getSearchEngineId(), companyId, documents);
+	}
+
+	private static final String VOCABULARY_ID = "vocabularyId";
+
+}

--- a/portal-service/src/com/liferay/portal/util/PortletKeys.java
+++ b/portal-service/src/com/liferay/portal/util/PortletKeys.java
@@ -35,6 +35,8 @@ public class PortletKeys {
 
 	public static final String ASSET_BROWSER = "172";
 
+	public static final String ASSET_CATEGORIES_ADMIN = "147";
+
 	public static final String ASSET_CATEGORIES_NAVIGATION = "122";
 
 	public static final String ASSET_PUBLISHER = "101";

--- a/portal-service/src/com/liferay/portlet/asset/service/AssetCategoryService.java
+++ b/portal-service/src/com/liferay/portlet/asset/service/AssetCategoryService.java
@@ -160,6 +160,13 @@ public interface AssetCategoryService extends BaseService {
 			com.liferay.portal.kernel.exception.SystemException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public com.liferay.portal.kernel.json.JSONObject getJSONVocabularyCategoriesByTitle(
+		long groupId, java.lang.String title, long vocabularyId, int start,
+		int end)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public java.util.List<com.liferay.portlet.asset.model.AssetCategory> getVocabularyCategories(
 		long vocabularyId, int start, int end,
 		com.liferay.portal.kernel.util.OrderByComparator obc)
@@ -178,6 +185,13 @@ public interface AssetCategoryService extends BaseService {
 		long groupId, java.lang.String name, long vocabularyId, int start,
 		int end, com.liferay.portal.kernel.util.OrderByComparator obc)
 		throws com.liferay.portal.kernel.exception.SystemException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.asset.model.AssetCategory> getVocabularyCategoriesByTitle(
+		long groupId, java.lang.String title, long vocabularyId, int start,
+		int end)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getVocabularyCategoriesCount(long groupId, long vocabularyId)
@@ -247,6 +261,13 @@ public interface AssetCategoryService extends BaseService {
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public com.liferay.portal.kernel.json.JSONArray search(long[] groupIds,
 		java.lang.String name, long[] vocabularyIds, int start, int end)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public com.liferay.portal.kernel.json.JSONArray searchTitle(
+		long[] groupIds, java.lang.String title, long[] vocabularyIds,
+		int start, int end)
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException;
 

--- a/portal-service/src/com/liferay/portlet/asset/service/AssetCategoryServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/asset/service/AssetCategoryServiceUtil.java
@@ -179,6 +179,16 @@ public class AssetCategoryServiceUtil {
 			start, end, obc);
 	}
 
+	public static com.liferay.portal.kernel.json.JSONObject getJSONVocabularyCategoriesByTitle(
+		long groupId, java.lang.String title, long vocabularyId, int start,
+		int end)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return getService()
+				   .getJSONVocabularyCategoriesByTitle(groupId, title,
+			vocabularyId, start, end);
+	}
+
 	public static java.util.List<com.liferay.portlet.asset.model.AssetCategory> getVocabularyCategories(
 		long vocabularyId, int start, int end,
 		com.liferay.portal.kernel.util.OrderByComparator obc)
@@ -205,6 +215,16 @@ public class AssetCategoryServiceUtil {
 		return getService()
 				   .getVocabularyCategories(groupId, name, vocabularyId, start,
 			end, obc);
+	}
+
+	public static java.util.List<com.liferay.portlet.asset.model.AssetCategory> getVocabularyCategoriesByTitle(
+		long groupId, java.lang.String title, long vocabularyId, int start,
+		int end)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return getService()
+				   .getVocabularyCategoriesByTitle(groupId, title,
+			vocabularyId, start, end);
 	}
 
 	public static int getVocabularyCategoriesCount(long groupId,
@@ -302,6 +322,15 @@ public class AssetCategoryServiceUtil {
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException {
 		return getService().search(groupIds, name, vocabularyIds, start, end);
+	}
+
+	public static com.liferay.portal.kernel.json.JSONArray searchTitle(
+		long[] groupIds, java.lang.String title, long[] vocabularyIds,
+		int start, int end)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return getService()
+				   .searchTitle(groupIds, title, vocabularyIds, start, end);
 	}
 
 	public static com.liferay.portlet.asset.model.AssetCategory updateCategory(

--- a/portal-service/src/com/liferay/portlet/asset/service/AssetCategoryServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/asset/service/AssetCategoryServiceWrapper.java
@@ -187,6 +187,16 @@ public class AssetCategoryServiceWrapper implements AssetCategoryService,
 	}
 
 	@Override
+	public com.liferay.portal.kernel.json.JSONObject getJSONVocabularyCategoriesByTitle(
+		long groupId, java.lang.String title, long vocabularyId, int start,
+		int end)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return _assetCategoryService.getJSONVocabularyCategoriesByTitle(groupId,
+			title, vocabularyId, start, end);
+	}
+
+	@Override
 	public java.util.List<com.liferay.portlet.asset.model.AssetCategory> getVocabularyCategories(
 		long vocabularyId, int start, int end,
 		com.liferay.portal.kernel.util.OrderByComparator obc)
@@ -213,6 +223,16 @@ public class AssetCategoryServiceWrapper implements AssetCategoryService,
 		throws com.liferay.portal.kernel.exception.SystemException {
 		return _assetCategoryService.getVocabularyCategories(groupId, name,
 			vocabularyId, start, end, obc);
+	}
+
+	@Override
+	public java.util.List<com.liferay.portlet.asset.model.AssetCategory> getVocabularyCategoriesByTitle(
+		long groupId, java.lang.String title, long vocabularyId, int start,
+		int end)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return _assetCategoryService.getVocabularyCategoriesByTitle(groupId,
+			title, vocabularyId, start, end);
 	}
 
 	@Override
@@ -318,6 +338,16 @@ public class AssetCategoryServiceWrapper implements AssetCategoryService,
 			com.liferay.portal.kernel.exception.SystemException {
 		return _assetCategoryService.search(groupIds, name, vocabularyIds,
 			start, end);
+	}
+
+	@Override
+	public com.liferay.portal.kernel.json.JSONArray searchTitle(
+		long[] groupIds, java.lang.String title, long[] vocabularyIds,
+		int start, int end)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return _assetCategoryService.searchTitle(groupIds, title,
+			vocabularyIds, start, end);
 	}
 
 	@Override

--- a/portal-service/src/com/liferay/portlet/asset/service/AssetVocabularyService.java
+++ b/portal-service/src/com/liferay/portlet/asset/service/AssetVocabularyService.java
@@ -152,6 +152,12 @@ public interface AssetVocabularyService extends BaseService {
 		throws com.liferay.portal.kernel.exception.SystemException;
 
 	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public java.util.List<com.liferay.portlet.asset.model.AssetVocabulary> getGroupVocabulariesByTitle(
+		long groupId, java.lang.String title, int start, int end)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
 	public int getGroupVocabulariesCount(long groupId)
 		throws com.liferay.portal.kernel.exception.SystemException;
 
@@ -171,6 +177,13 @@ public interface AssetVocabularyService extends BaseService {
 	public com.liferay.portlet.asset.model.AssetVocabularyDisplay getGroupVocabulariesDisplay(
 		long groupId, java.lang.String name, int start, int end,
 		com.liferay.portal.kernel.util.OrderByComparator obc)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException;
+
+	@Transactional(propagation = Propagation.SUPPORTS, readOnly = true)
+	public com.liferay.portlet.asset.model.AssetVocabularyDisplay getGroupVocabulariesDisplayByTitle(
+		long groupId, java.lang.String title, int start, int end,
+		boolean addDefaultVocabulary)
 		throws com.liferay.portal.kernel.exception.PortalException,
 			com.liferay.portal.kernel.exception.SystemException;
 

--- a/portal-service/src/com/liferay/portlet/asset/service/AssetVocabularyServiceUtil.java
+++ b/portal-service/src/com/liferay/portlet/asset/service/AssetVocabularyServiceUtil.java
@@ -172,6 +172,14 @@ public class AssetVocabularyServiceUtil {
 		return getService().getGroupVocabularies(groupId, name, start, end, obc);
 	}
 
+	public static java.util.List<com.liferay.portlet.asset.model.AssetVocabulary> getGroupVocabulariesByTitle(
+		long groupId, java.lang.String title, int start, int end)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return getService()
+				   .getGroupVocabulariesByTitle(groupId, title, start, end);
+	}
+
 	public static int getGroupVocabulariesCount(long groupId)
 		throws com.liferay.portal.kernel.exception.SystemException {
 		return getService().getGroupVocabulariesCount(groupId);
@@ -201,6 +209,16 @@ public class AssetVocabularyServiceUtil {
 			com.liferay.portal.kernel.exception.SystemException {
 		return getService()
 				   .getGroupVocabulariesDisplay(groupId, name, start, end, obc);
+	}
+
+	public static com.liferay.portlet.asset.model.AssetVocabularyDisplay getGroupVocabulariesDisplayByTitle(
+		long groupId, java.lang.String title, int start, int end,
+		boolean addDefaultVocabulary)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return getService()
+				   .getGroupVocabulariesDisplayByTitle(groupId, title, start,
+			end, addDefaultVocabulary);
 	}
 
 	/**

--- a/portal-service/src/com/liferay/portlet/asset/service/AssetVocabularyServiceWrapper.java
+++ b/portal-service/src/com/liferay/portlet/asset/service/AssetVocabularyServiceWrapper.java
@@ -181,6 +181,15 @@ public class AssetVocabularyServiceWrapper implements AssetVocabularyService,
 	}
 
 	@Override
+	public java.util.List<com.liferay.portlet.asset.model.AssetVocabulary> getGroupVocabulariesByTitle(
+		long groupId, java.lang.String title, int start, int end)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return _assetVocabularyService.getGroupVocabulariesByTitle(groupId,
+			title, start, end);
+	}
+
+	@Override
 	public int getGroupVocabulariesCount(long groupId)
 		throws com.liferay.portal.kernel.exception.SystemException {
 		return _assetVocabularyService.getGroupVocabulariesCount(groupId);
@@ -211,6 +220,16 @@ public class AssetVocabularyServiceWrapper implements AssetVocabularyService,
 			com.liferay.portal.kernel.exception.SystemException {
 		return _assetVocabularyService.getGroupVocabulariesDisplay(groupId,
 			name, start, end, obc);
+	}
+
+	@Override
+	public com.liferay.portlet.asset.model.AssetVocabularyDisplay getGroupVocabulariesDisplayByTitle(
+		long groupId, java.lang.String title, int start, int end,
+		boolean addDefaultVocabulary)
+		throws com.liferay.portal.kernel.exception.PortalException,
+			com.liferay.portal.kernel.exception.SystemException {
+		return _assetVocabularyService.getGroupVocabulariesDisplayByTitle(groupId,
+			title, start, end, addDefaultVocabulary);
 	}
 
 	/**

--- a/portal-web/docroot/WEB-INF/liferay-portlet.xml
+++ b/portal-web/docroot/WEB-INF/liferay-portlet.xml
@@ -1456,6 +1456,8 @@
 		<portlet-name>147</portlet-name>
 		<icon>/html/icons/asset_category_admin.png</icon>
 		<struts-path>asset_category_admin</struts-path>
+		<indexer-class>com.liferay.portlet.asset.util.AssetCategoryIndexer</indexer-class>
+		<indexer-class>com.liferay.portlet.asset.util.AssetVocabularyIndexer</indexer-class>
 		<staged-model-data-handler-class>com.liferay.portlet.asset.lar.AssetCategoryStagedModelDataHandler</staged-model-data-handler-class>
 		<staged-model-data-handler-class>com.liferay.portlet.asset.lar.AssetVocabularyStagedModelDataHandler</staged-model-data-handler-class>
 		<control-panel-entry-category>site_administration.content</control-panel-entry-category>

--- a/portal-web/docroot/html/js/liferay/asset_categories_selector.js
+++ b/portal-web/docroot/html/js/liferay/asset_categories_selector.js
@@ -28,10 +28,10 @@ AUI.add(
 		var TPL_CHECKED = ' checked="checked" ';
 
 		var TPL_INPUT =
-			'<label title="{name}">' +
-				'<span class="lfr-categories-selector-category-name" title="{name}">' +
-					'<input data-categoryId="{categoryId}" data-vocabularyid="{vocabularyId}" name="{inputName}" type="{type}" value="{name}" {checked} />' +
-					'{name}' +
+			'<label title="{titleCurrentValue}">' +
+				'<span class="lfr-categories-selector-category-name" title="{titleCurrentValue}">' +
+					'<input data-categoryId="{categoryId}" data-vocabularyid="{vocabularyId}" name="{inputName}" type="{type}" value="{titleCurrentValue}" {checked} />' +
+					'{titleCurrentValue}' +
 				'</span>' +
 				'<span class="lfr-categories-selector-search-results-path" title="{path}">{path}</span>' +
 			'</label>';
@@ -582,10 +582,10 @@ AUI.add(
 							searchResults.addClass('loading-animation');
 
 							Liferay.Service(
-								'/assetcategory/search',
+								'/assetcategory/search-title',
 								{
 									groupIds: vocabularyGroupIds,
-									name: Lang.sub(TPL_SEARCH_QUERY, [searchValue]),
+									title: Lang.sub(TPL_SEARCH_QUERY, [searchValue]),
 									vocabularyIds: vocabularyIds,
 									start: -1,
 									end: -1

--- a/portal-web/docroot/html/portlet/asset_category_admin/js/main.js
+++ b/portal-web/docroot/html/portlet/asset_category_admin/js/main.js
@@ -163,10 +163,10 @@ AUI.add(
 		var STR_ROWS_PER_PAGE = 'rowsPerPage';
 
 		var TPL_CATEGORY_ITEM =
-			'<label class="category-item" id="categoryNode{categoryId}" title="{name}">' +
-				'<span class="category-name" title="{name}">' +
-					'<input class="category-item-check" data-categoryId="{categoryId}" name="category-item-check" type="checkbox" value="{name}" {checked} />' +
-					'{name}' +
+			'<label class="category-item" id="categoryNode{categoryId}" title="{titleCurrentValue}">' +
+				'<span class="category-name" title="{titleCurrentValue}">' +
+					'<input class="category-item-check" data-categoryId="{categoryId}" name="category-item-check" type="checkbox" value="{titleCurrentValue}" {checked} />' +
+					'{titleCurrentValue}' +
 				'</span>' +
 				'<span class="category-path" title="{path}">{path}</span>' +
 			'</label>';
@@ -1482,13 +1482,12 @@ AUI.add(
 
 						Liferay.Service(
 							{
-								'$display = /assetvocabulary/get-group-vocabularies-display': {
+								'$display = /assetvocabulary/get-group-vocabularies-display-by-title': {
 									groupId: parentGroupId,
-									name: query,
+									title: query,
 									start: start,
 									end: end,
 									addDefaultVocabulary: true,
-									obc: null,
 									'vocabularies.$categoriesCount = /assetcategory/get-vocabulary-root-categories-count': {
 										groupId: parentGroupId,
 										'@vocabularyId': '$display.vocabularies.vocabularyId'
@@ -1527,7 +1526,6 @@ AUI.add(
 							vocabularyId: vocabularyId,
 							start: -1,
 							end: -1,
-							obc: null
 						};
 
 						var query = instance._liveSearch.get(STR_QUERY);
@@ -1538,13 +1536,13 @@ AUI.add(
 							params = A.mix(
 								{
 									groupId: themeDisplay.getSiteGroupId(),
-									name: Lang.sub(TPL_SEARCH_QUERY, [query])
+									title: Lang.sub(TPL_SEARCH_QUERY, [query])
 								},
 								defaultParams
 							);
 						}
 
-						Liferay.Service('/assetcategory/get-json-vocabulary-categories', params, callback);
+						Liferay.Service('/assetcategory/get-json-vocabulary-categories-by-title', params, callback);
 					},
 
 					_getVocabularyCategoriesTree: function(vocabularyId, callback) {


### PR DESCRIPTION
Hi Tamás,

This is a correction for the behaviour of the Asset Category and Asset Vocabulary searches. The search subjects and results for these items are currently the name fields, which are not localized in the users display language.
Contrary to this, the title field is localized, which means that the user can assign translations in multiple languages to it.
With the modification, the user is able to search Categories and Vocabularies in their own language, by searching after title instead of name. This is achieved by modifying the search service of both Asset Category and Asset Vocabulary, and providing Indexers to these entities (AssetCategoryIndexer and AssetVocabularyIndexer, respectively). Hence, the search is turned from DB based to Indexer based.
I created to subtasks for implementing the Indexers:

LPS-44155 Add Indexer for Asset Categories
LPS-44157 Add Indexer for Vocabularies

Best Regards,
István
