### PR TITLE
[TECHNICAL SUPPORT] LPS-44021 Added getGroupId and setGroupId methods to the LayoutRevisionMethods list

### DIFF
--- a/portal-service/src/com/liferay/portal/model/LayoutStagingHandler.java
+++ b/portal-service/src/com/liferay/portal/model/LayoutStagingHandler.java
@@ -319,6 +319,7 @@ public class LayoutStagingHandler implements InvocationHandler, Serializable {
 		_layoutRevisionMethodNames.add("getIconImage");
 		_layoutRevisionMethodNames.add("getIconImageId");
 		_layoutRevisionMethodNames.add("getKeywords");
+		_layoutRevisionMethodNames.add("getLayoutSet");
 		_layoutRevisionMethodNames.add("getName");
 		_layoutRevisionMethodNames.add("getRobots");
 		_layoutRevisionMethodNames.add("getTheme");


### PR DESCRIPTION
Hey Tamás,

This issue take care about https://issues.liferay.com/browse/LPS-35222 when LayoutRevisions are used, as the setGroupId() method sets the Layout's groupId, instead of the LayoutRevision's which leads to NoSuchLayoutSetExceptions during import, as the groupId will remain the same (staging site's groupId), loaded from the XML file. I also had to add getLayoutSet() method to the list, to use the proper one.

If you have any questions, concerns, please let me know.
