### PR TITLE
[TECHNICAL SUPPORT] LPS-45579 Asset Publisher shows abstracts as escaped html code for message boards

### DIFF
--- a/portal-web/docroot/html/portlet/message_boards/asset/abstract.jsp
+++ b/portal-web/docroot/html/portlet/message_boards/asset/abstract.jsp
@@ -21,11 +21,14 @@ int abstractLength = (Integer)request.getAttribute(WebKeys.ASSET_PUBLISHER_ABSTR
 
 MBMessage message = (MBMessage)request.getAttribute(WebKeys.MESSAGE_BOARDS_MESSAGE);
 
-String summary = StringUtil.shorten(message.getBody(), abstractLength);
+String summary = message.getBody();
 
 if (message.isFormatBBCode()) {
 	summary = MBUtil.getBBCodeHTML(summary, themeDisplay.getPathThemeImages());
 }
+else {
+	summary = HtmlUtil.unescape(summary);
+}
 %>
 
-<%= HtmlUtil.escape(summary) %>
+<%= StringUtil.shorten(HtmlUtil.extractText(summary), abstractLength) %>


### PR DESCRIPTION
Hi @moltam89!

The original pattern is a bit different (see for example portal-web\docroot\html\portlet\wiki\asset\abstract.jsp) but that pattern uses HtmlUtil.stripHtml which is not appropriate for the task.

Moreover, trunk saves mbmessages as if it would be in 'bbcode' format, so testing is a bit hard, but try to create a very long URL.
