### PR TITLE
[TECHNICAL SUPPORT] LPS-46131 File size related exceptions not handled properly for Commons File Upload

### DIFF
--- a/portal-impl/src/com/liferay/portal/editor/fckeditor/receiver/impl/BaseCommandReceiver.java
+++ b/portal-impl/src/com/liferay/portal/editor/fckeditor/receiver/impl/BaseCommandReceiver.java
@@ -240,8 +240,9 @@ public abstract class BaseCommandReceiver implements CommandReceiver {
 				else if (causeString.contains("PrincipalException")) {
 					returnValue = "207";
 				}
-				else if (causeString.contains("ImageSizeException") ||
-						 causeString.contains("FileSizeException")) {
+				else if (causeString.contains("FileSizeException") ||
+						 causeString.contains("ImageSizeException") ||
+						 causeString.contains("SizeLimitExceededException")) {
 
 					returnValue = "208";
 				}


### PR DESCRIPTION
Hi Tomcsi,

As we already discussed I'v only added the extra handling for file size limit detection with by checking the thrown FileSizeLimitExceededException and SizeLimitExceededException from commons file upload library.
