### PR TITLE
[TECHNICAL-SUPPORT] LPS-76690 The 'Link' function in web contents cannot be published with non default locales.

### DIFF
--- a/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/content/processor/base/BaseTextExportImportContentProcessor.java
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/content/processor/base/BaseTextExportImportContentProcessor.java
@@ -1535,12 +1535,8 @@ public class BaseTextExportImportContentProcessor
 
 			url = url.substring(pos);
 
-			layout = LayoutLocalServiceUtil.fetchLayoutByFriendlyURL(
+			layout = LayoutLocalServiceUtil.getFriendlyURLLayout(
 				urlGroup.getGroupId(), privateLayout, url);
-
-			if (layout == null) {
-				throw new NoSuchLayoutException();
-			}
 		}
 	}
 

--- a/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -848,13 +848,15 @@ public class LayoutReferencesExportImportContentProcessor
 
 			url = url.substring(pos);
 
-			layout = _layoutLocalService.fetchLayoutByFriendlyURL(
-				urlGroup.getGroupId(), privateLayout, url);
-
-			if (layout == null) {
+			try {
+				layout = _layoutLocalService.getFriendlyURLLayout(
+					urlGroup.getGroupId(), privateLayout, url);
+			}
+			catch (NoSuchLayoutException nsle) {
 				throw new NoSuchLayoutException(
 					"Unable to validate referenced page because the page " +
-						"group cannot be found: " + groupId);
+						"group cannot be found: " + groupId,
+					nsle);
 			}
 		}
 	}

--- a/modules/apps/web-experience/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/DefaultExportImportContentProcessorTest.java
+++ b/modules/apps/web-experience/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/DefaultExportImportContentProcessorTest.java
@@ -50,6 +50,8 @@ import com.liferay.portal.kernel.service.GroupLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.ServiceContext;
 import com.liferay.portal.kernel.test.ReflectionTestUtil;
+import com.liferay.portal.kernel.test.randomizerbumpers.NumericStringRandomizerBumper;
+import com.liferay.portal.kernel.test.randomizerbumpers.UniqueStringRandomizerBumper;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.rule.DeleteAfterTestRun;
 import com.liferay.portal.kernel.test.util.GroupTestUtil;
@@ -57,7 +59,9 @@ import com.liferay.portal.kernel.test.util.RandomTestUtil;
 import com.liferay.portal.kernel.test.util.ServiceContextTestUtil;
 import com.liferay.portal.kernel.test.util.TestPropsValues;
 import com.liferay.portal.kernel.util.ContentTypes;
+import com.liferay.portal.kernel.util.FriendlyURLNormalizerUtil;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.Portal;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.StringBundler;
@@ -67,6 +71,7 @@ import com.liferay.portal.kernel.util.Time;
 import com.liferay.portal.kernel.xml.Document;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.kernel.xml.SAXReaderUtil;
+import com.liferay.portal.test.randomizerbumpers.FriendlyURLRandomizerBumper;
 import com.liferay.portal.test.randomizerbumpers.TikaSafeRandomizerBumper;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
 import com.liferay.portal.util.PortalImpl;
@@ -89,6 +94,7 @@ import java.util.Arrays;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Scanner;
 import java.util.regex.Matcher;
@@ -134,6 +140,9 @@ public class DefaultExportImportContentProcessorTest {
 
 	@Before
 	public void setUp() throws Exception {
+		_defaultLocale = LocaleUtil.getDefault();
+		_nonDefaultLocale = getNonDefaultLocale();
+
 		_liveGroup = GroupTestUtil.addGroup();
 		_stagingGroup = GroupTestUtil.addGroup();
 
@@ -175,8 +184,8 @@ public class DefaultExportImportContentProcessorTest {
 
 		_portletDataContextExport.setExportDataRootElement(rootElement);
 
-		_stagingPrivateLayout = LayoutTestUtil.addLayout(_stagingGroup, true);
-		_stagingPublicLayout = LayoutTestUtil.addLayout(_stagingGroup, false);
+		_stagingPrivateLayout = addMultiLocaleLayout(_stagingGroup, true);
+		_stagingPublicLayout = addMultiLocaleLayout(_stagingGroup, false);
 
 		_portletDataContextExport.setPlid(_stagingPublicLayout.getPlid());
 
@@ -196,8 +205,8 @@ public class DefaultExportImportContentProcessorTest {
 		_portletDataContextImport.setMissingReferencesElement(
 			missingReferencesElement);
 
-		_livePrivateLayout = LayoutTestUtil.addLayout(_liveGroup, true);
-		_livePublicLayout = LayoutTestUtil.addLayout(_liveGroup, false);
+		_livePrivateLayout = addMultiLocaleLayout(_liveGroup, true);
+		_livePublicLayout = addMultiLocaleLayout(_liveGroup, false);
 
 		Map<Long, Long> layoutPlids =
 			(Map<Long, Long>)_portletDataContextImport.getNewPrimaryKeysMap(
@@ -716,6 +725,30 @@ public class DefaultExportImportContentProcessorTest {
 		portalUtil.setPortal(new PortalImpl());
 	}
 
+	protected Layout addMultiLocaleLayout(Group group, boolean privateLayout)
+		throws Exception {
+
+		Map<Locale, String> nameMap = new HashMap<>();
+		Map<Locale, String> firendlyUrlMap = new HashMap<>();
+
+		for (Locale locale : new Locale[] {_defaultLocale, _nonDefaultLocale}) {
+			String name = RandomTestUtil.randomString(
+				FriendlyURLRandomizerBumper.INSTANCE,
+				NumericStringRandomizerBumper.INSTANCE,
+				UniqueStringRandomizerBumper.INSTANCE);
+
+			String friendlyURL =
+				StringPool.SLASH + FriendlyURLNormalizerUtil.normalize(name);
+
+			nameMap.put(locale, name);
+
+			firendlyUrlMap.put(locale, friendlyURL);
+		}
+
+		return LayoutTestUtil.addLayout(
+			group.getGroupId(), privateLayout, nameMap, firendlyUrlMap);
+	}
+
 	protected void assertLinksToLayouts(
 		String content, Layout layout, long groupId) {
 
@@ -828,6 +861,16 @@ public class DefaultExportImportContentProcessorTest {
 		return scanner.next();
 	}
 
+	protected Locale getNonDefaultLocale() throws Exception {
+		for (Locale locale : _locales) {
+			if (!locale.equals(_defaultLocale)) {
+				return locale;
+			}
+		}
+
+		throw new Exception("Could not find a non-default locale");
+	}
+
 	protected List<String> getURLs(String content) {
 		Matcher matcher = _pattern.matcher(StringPool.BLANK);
 
@@ -863,9 +906,41 @@ public class DefaultExportImportContentProcessorTest {
 			});
 	}
 
+	protected String replaceMultiLocaleLayoutFriendlyURLs(String content) {
+		if (StringUtil.indexOfAny(content, _multiLocaleLayoutVariables) <= -1) {
+			return content;
+		}
+
+		List<String> urls = ListUtil.toList(StringUtil.splitLines(content));
+
+		List<String> outURLs = new ArrayList<>();
+
+		for (String url : urls) {
+			outURLs.add(url);
+
+			if (StringUtil.indexOfAny(url, _multiLocaleLayoutVariables) > -1) {
+				outURLs.add(
+					StringUtil.replace(
+						url, _multiLocaleLayoutVariables,
+						_nonDefaultMultiLocaleLayoutVariables));
+			}
+		}
+
+		return StringUtil.merge(outURLs, StringPool.NEW_LINE);
+	}
+
 	protected String replaceParameters(String content, FileEntry fileEntry) {
 		Company company = CompanyLocalServiceUtil.fetchCompany(
 			fileEntry.getCompanyId());
+
+		content = replaceMultiLocaleLayoutFriendlyURLs(content);
+
+		Map<Locale, String> livePublicLayoutFriendlyUrls =
+			_livePublicLayout.getFriendlyURLMap();
+		Map<Locale, String> stagingPrivateLayoutFriendlyUrls =
+			_stagingPrivateLayout.getFriendlyURLMap();
+		Map<Locale, String> stagingPublicLayoutFriendlyUrls =
+			_stagingPublicLayout.getFriendlyURLMap();
 
 		content = StringUtil.replace(
 			content,
@@ -874,8 +949,11 @@ public class DefaultExportImportContentProcessorTest {
 				"[$CONTROL_PANEL_LAYOUT_FRIENDLY_URL$]",
 				"[$GROUP_FRIENDLY_URL$]", "[$GROUP_ID$]", "[$IMAGE_ID$]",
 				"[$LIVE_GROUP_FRIENDLY_URL$]", "[$LIVE_GROUP_ID$]",
-				"[$LIVE_PUBLIC_LAYOUT_FRIENDLY_URL$]", "[$PATH_CONTEXT$]",
-				"[$PATH_FRIENDLY_URL_PRIVATE_GROUP$]",
+				"[$LIVE_PUBLIC_LAYOUT_FRIENDLY_URL$]",
+				"[$NON_DEFAULT_LIVE_PUBLIC_LAYOUT_FRIENDLY_URL$]",
+				"[$NON_DEFAULT_PRIVATE_LAYOUT_FRIENDLY_URL$]",
+				"[$NON_DEFAULT_PUBLIC_LAYOUT_FRIENDLY_URL$]",
+				"[$PATH_CONTEXT$]", "[$PATH_FRIENDLY_URL_PRIVATE_GROUP$]",
 				"[$PATH_FRIENDLY_URL_PRIVATE_USER$]",
 				"[$PATH_FRIENDLY_URL_PUBLIC$]",
 				"[$PRIVATE_LAYOUT_FRIENDLY_URL$]",
@@ -891,7 +969,11 @@ public class DefaultExportImportContentProcessorTest {
 				String.valueOf(fileEntry.getFileEntryId()),
 				_liveGroup.getFriendlyURL(),
 				String.valueOf(_liveGroup.getGroupId()),
-				_livePublicLayout.getFriendlyURL(), PortalUtil.getPathContext(),
+				_livePublicLayout.getFriendlyURL(),
+				livePublicLayoutFriendlyUrls.get(_nonDefaultLocale),
+				stagingPrivateLayoutFriendlyUrls.get(_nonDefaultLocale),
+				stagingPublicLayoutFriendlyUrls.get(_nonDefaultLocale),
+				PortalUtil.getPathContext(),
 				PropsValues.LAYOUT_FRIENDLY_URL_PRIVATE_GROUP_SERVLET_MAPPING,
 				PropsValues.LAYOUT_FRIENDLY_URL_PRIVATE_USER_SERVLET_MAPPING,
 				PropsValues.LAYOUT_FRIENDLY_URL_PUBLIC_SERVLET_MAPPING,
@@ -989,11 +1071,23 @@ public class DefaultExportImportContentProcessorTest {
 			entriesStream.anyMatch(entry -> entry.endsWith(expected)));
 	}
 
+	private static final Locale[] _locales =
+		{LocaleUtil.US, LocaleUtil.GERMANY, LocaleUtil.SPAIN};
+	private static final String[] _multiLocaleLayoutVariables = {
+		"[$LIVE_PUBLIC_LAYOUT_FRIENDLY_URL$]",
+		"[$PRIVATE_LAYOUT_FRIENDLY_URL$]", "[$PUBLIC_LAYOUT_FRIENDLY_URL$]"
+	};
+	private static final String[] _nonDefaultMultiLocaleLayoutVariables = {
+		"[$NON_DEFAULT_LIVE_PUBLIC_LAYOUT_FRIENDLY_URL$]",
+		"[$NON_DEFAULT_PRIVATE_LAYOUT_FRIENDLY_URL$]",
+		"[$NON_DEFAULT_PUBLIC_LAYOUT_FRIENDLY_URL$]"
+	};
 	private static String _oldLayoutFriendlyURLPrivateUserServletMapping;
 	private static ServiceTracker
 		<ExportImportContentProcessor,
 			ExportImportContentProcessor> _serviceTracker;
 
+	private Locale _defaultLocale;
 	private ExportImportContentProcessor<String> _exportImportContentProcessor;
 	private FileEntry _fileEntry;
 	private ExportImportContentProcessor<String>
@@ -1004,6 +1098,7 @@ public class DefaultExportImportContentProcessorTest {
 
 	private Layout _livePrivateLayout;
 	private Layout _livePublicLayout;
+	private Locale _nonDefaultLocale;
 	private final Pattern _pattern = Pattern.compile("href=|\\{|\\[");
 	private PortletDataContext _portletDataContextExport;
 	private PortletDataContext _portletDataContextImport;


### PR DESCRIPTION
Hi @moltam89 ,

As discussed in the previous pull requests #404 , #407, separated the commits into 2 tickets, this for the original bug.

The integration tests did not catch the issue, because they were creating Layouts with a single Locale. Updated the tests to always create Layouts with multiple Locales and multiple Friendly URLs.
Test-case generation now uses Friendly URLs for both locales of a Layout: the default and the non-default one.

This pull request is a conflict resolving for #406

Thanks,
Vendel