### PR TITLE
LPS-78466 Broken hyperlinks in basic webcontent after import

### DIFF
--- a/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -442,11 +442,13 @@ public class LayoutReferencesExportImportContentProcessor
 				}
 				else {
 					urlSB.append(urlGroup.getUuid());
-					
-					urlSB.append(StringPool.AT);
-					urlSB.append(StringPool.AT);
-					
-					urlSB.append(urlGroup.getFriendlyURL());
+
+					if (!urlGroup.isControlPanel()) {
+						urlSB.append(StringPool.AT);
+						urlSB.append(StringPool.AT);
+
+						urlSB.append(urlGroup.getFriendlyURL());
+					}
 				}
 
 				urlSB.append(StringPool.AT);
@@ -620,30 +622,41 @@ public class LayoutReferencesExportImportContentProcessor
 			}
 
 			String groupUuid = content.substring(groupUuidPos + 1, endIndex);
-			
+
+			int optionalGroupFriendlyUrlPos = endIndex + 1;
 			String optionalGroupFriendlyUrl = null;
-			
-			if (content.substring(endIndex + 1, endIndex + 2).equals(StringPool.AT)) {
-				int groupFriendlyUrlEndIndex = content.indexOf(StringPool.AT, endIndex + 2);
-				
-				optionalGroupFriendlyUrl = content.substring(endIndex + 2, groupFriendlyUrlEndIndex);
+
+			if (content.charAt(optionalGroupFriendlyUrlPos) == CharPool.AT) {
+				int optionalGroupFriendlyUrlEndIndex = content.indexOf(
+					StringPool.AT, optionalGroupFriendlyUrlPos + 1);
+
+				if (optionalGroupFriendlyUrlEndIndex > -1) {
+					optionalGroupFriendlyUrl = content.substring(
+						optionalGroupFriendlyUrlPos + 1,
+						optionalGroupFriendlyUrlEndIndex);
+				}
 			}
 
 			Group groupFriendlyUrlGroup =
 				_groupLocalService.fetchGroupByUuidAndCompanyId(
 					groupUuid, portletDataContext.getCompanyId());
 
-			if (groupFriendlyUrlGroup == null && optionalGroupFriendlyUrl != null) {
-				groupFriendlyUrlGroup = _groupLocalService.fetchFriendlyURLGroup(
-					portletDataContext.getCompanyId(), optionalGroupFriendlyUrl);								
+			if ((groupFriendlyUrlGroup == null) &&
+				(optionalGroupFriendlyUrl != null)) {
+
+				groupFriendlyUrlGroup =
+					_groupLocalService.fetchFriendlyURLGroup(
+						portletDataContext.getCompanyId(),
+						optionalGroupFriendlyUrl);
 			}
-			
+
 			if (optionalGroupFriendlyUrl != null) {
 				content = StringUtil.replaceFirst(
-					content, StringPool.AT + optionalGroupFriendlyUrl + StringPool.AT,
-					StringPool.BLANK, groupFriendlyUrlPos);
+					content,
+					StringPool.AT + optionalGroupFriendlyUrl + StringPool.AT,
+					StringPool.BLANK, optionalGroupFriendlyUrlPos);
 			}
-			
+
 			if ((groupFriendlyUrlGroup == null) ||
 				groupUuid.startsWith(StringPool.SLASH)) {
 

--- a/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -442,6 +442,11 @@ public class LayoutReferencesExportImportContentProcessor
 				}
 				else {
 					urlSB.append(urlGroup.getUuid());
+					
+					urlSB.append(StringPool.AT);
+					urlSB.append(StringPool.AT);
+					
+					urlSB.append(urlGroup.getFriendlyURL());
 				}
 
 				urlSB.append(StringPool.AT);
@@ -615,11 +620,30 @@ public class LayoutReferencesExportImportContentProcessor
 			}
 
 			String groupUuid = content.substring(groupUuidPos + 1, endIndex);
+			
+			String optionalGroupFriendlyUrl = null;
+			
+			if (content.substring(endIndex + 1, endIndex + 2).equals(StringPool.AT)) {
+				int groupFriendlyUrlEndIndex = content.indexOf(StringPool.AT, endIndex + 2);
+				
+				optionalGroupFriendlyUrl = content.substring(endIndex + 2, groupFriendlyUrlEndIndex);
+			}
 
 			Group groupFriendlyUrlGroup =
 				_groupLocalService.fetchGroupByUuidAndCompanyId(
 					groupUuid, portletDataContext.getCompanyId());
 
+			if (groupFriendlyUrlGroup == null && optionalGroupFriendlyUrl != null) {
+				groupFriendlyUrlGroup = _groupLocalService.fetchFriendlyURLGroup(
+					portletDataContext.getCompanyId(), optionalGroupFriendlyUrl);								
+			}
+			
+			if (optionalGroupFriendlyUrl != null) {
+				content = StringUtil.replaceFirst(
+					content, StringPool.AT + optionalGroupFriendlyUrl + StringPool.AT,
+					StringPool.BLANK, groupFriendlyUrlPos);
+			}
+			
 			if ((groupFriendlyUrlGroup == null) ||
 				groupUuid.startsWith(StringPool.SLASH)) {
 


### PR DESCRIPTION
Hi @moltam89 ,

The initial version of the fix for exporting/importing links pointing to layouts in external groups is ready.
I have added a new test case as well and extended the default link samples to contain a link to an external group. See my comments on the LPP for more details about the issue.
Please review my changes.

Thanks,
Vendel