### PR TITLE
LPS-78466 Broken hyperlinks in basic webcontent after import

### DIFF
--- a/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/web-experience/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -437,7 +437,7 @@ public class LayoutReferencesExportImportContentProcessor
 
 					urlSB.append(liveGroup.getUuid());
 				}
-				else if (group.getGroupId() == urlGroup.getGroupId()) {
+				else if (!urlGroup.isControlPanel()) {
 					urlSB.append(urlGroup.getFriendlyURL());
 				}
 				else {
@@ -620,9 +620,13 @@ public class LayoutReferencesExportImportContentProcessor
 				_groupLocalService.fetchGroupByUuidAndCompanyId(
 					groupUuid, portletDataContext.getCompanyId());
 
-			if ((groupFriendlyUrlGroup == null) ||
-				groupUuid.startsWith(StringPool.SLASH)) {
+			if (groupFriendlyUrlGroup == null) {
+				groupFriendlyUrlGroup =
+					_groupLocalService.fetchFriendlyURLGroup(
+						portletDataContext.getCompanyId(), groupUuid);
+			}
 
+			if (groupFriendlyUrlGroup == null) {
 				content = StringUtil.replaceFirst(
 					content, _DATA_HANDLER_GROUP_FRIENDLY_URL,
 					group.getFriendlyURL(), groupFriendlyUrlPos);


### PR DESCRIPTION
Hi @moltam89 ,

As discussed in #414 , I modified the fix: it will not add an extra "@@" variable into the LAR file, but it will use the friendlyURL variable instead of the UUID, when the export type is not Local/Remote publication and the group type is not control_panel. Likewise, I changed the import to search by UUID and friendlyURL as well, removed the check for startsWith("/"), since it's not required: the fetch lookup will find the group either way.

Thanks,
Vendel