### PR TITLE
[TECHNICAL-SUPPORT] LPS-83064

### DIFF
--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/exportimport/data/handler/KBArticleStagedModelDataHandler.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/exportimport/data/handler/KBArticleStagedModelDataHandler.java
@@ -20,6 +20,7 @@ import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.exportimport.kernel.lar.BaseStagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.ExportImportPathUtil;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.exportimport.kernel.lar.PortletDataException;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.exportimport.kernel.lar.StagedModelModifiedDateComparator;
@@ -438,6 +439,48 @@ public class KBArticleStagedModelDataHandler
 				if (_log.isDebugEnabled()) {
 					_log.debug(dfee, dfee);
 				}
+			}
+		}
+	}
+
+	@Override
+	protected void importReferenceStagedModels(
+			PortletDataContext portletDataContext, KBArticle stagedModel)
+		throws PortletDataException {
+
+		super.importReferenceStagedModels(portletDataContext, stagedModel);
+
+		Element stagedModelElement =
+			portletDataContext.getImportDataStagedModelElement(stagedModel);
+
+		Element referencesElement = stagedModelElement.element("references");
+
+		List<Element> referenceElements = referencesElement.elements();
+
+		for (Element referenceElement : referenceElements) {
+			String referenceType = referenceElement.attributeValue("type");
+
+			if (referenceType.equals(
+					PortletDataContext.REFERENCE_TYPE_PARENT)) {
+
+				long kbArticleClassNameId = _portal.getClassNameId(
+					KBArticleConstants.getClassName());
+				long kbFolderClassNameId = _portal.getClassNameId(
+					KBFolderConstants.getClassName());
+
+				String className = referenceElement.attributeValue(
+					"class-name");
+
+				if (className.equals(KBArticle.class.getName())) {
+					stagedModel.setParentResourceClassNameId(
+						kbArticleClassNameId);
+				}
+				else {
+					stagedModel.setParentResourceClassNameId(
+						kbFolderClassNameId);
+				}
+
+				break;
 			}
 		}
 	}

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/exportimport/data/handler/KBArticleStagedModelDataHandler.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/exportimport/data/handler/KBArticleStagedModelDataHandler.java
@@ -190,23 +190,6 @@ public class KBArticleStagedModelDataHandler
 		long kbFolderClassNameId = _portal.getClassNameId(
 			KBFolderConstants.getClassName());
 
-		if ((kbArticle.getParentResourceClassNameId() !=
-				kbArticle.getClassNameId()) &&
-			(kbArticle.getParentResourceClassNameId() != kbFolderClassNameId)) {
-
-			KBArticle parentKBArticle =
-				_kbArticleLocalService.fetchLatestKBArticle(
-					parentResourcePrimKey, WorkflowConstants.STATUS_APPROVED);
-
-			if (parentKBArticle != null) {
-				kbArticle.setParentResourceClassNameId(
-					kbArticle.getClassNameId());
-			}
-			else {
-				kbArticle.setParentResourceClassNameId(kbFolderClassNameId);
-			}
-		}
-
 		if (kbArticle.getParentResourcePrimKey() !=
 				KBFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
 

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/exportimport/data/handler/KBArticleStagedModelDataHandler.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/exportimport/data/handler/KBArticleStagedModelDataHandler.java
@@ -438,6 +438,17 @@ public class KBArticleStagedModelDataHandler
 
 		Element referencesElement = stagedModelElement.element("references");
 
+		long kbArticleClassNameId = _portal.getClassNameId(
+			KBArticleConstants.getClassName());
+		long kbFolderClassNameId = _portal.getClassNameId(
+			KBFolderConstants.getClassName());
+
+		if (referencesElement == null) {
+			stagedModel.setParentResourceClassNameId(kbFolderClassNameId);
+
+			return;
+		}
+
 		List<Element> referenceElements = referencesElement.elements();
 
 		for (Element referenceElement : referenceElements) {
@@ -445,11 +456,6 @@ public class KBArticleStagedModelDataHandler
 
 			if (referenceType.equals(
 					PortletDataContext.REFERENCE_TYPE_PARENT)) {
-
-				long kbArticleClassNameId = _portal.getClassNameId(
-					KBArticleConstants.getClassName());
-				long kbFolderClassNameId = _portal.getClassNameId(
-					KBFolderConstants.getClassName());
 
 				String className = referenceElement.attributeValue(
 					"class-name");

--- a/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/exportimport/data/handler/KBArticleStagedModelDataHandler.java
+++ b/modules/apps/knowledge-base/knowledge-base-service/src/main/java/com/liferay/knowledge/base/internal/exportimport/data/handler/KBArticleStagedModelDataHandler.java
@@ -187,9 +187,6 @@ public class KBArticleStagedModelDataHandler
 			kbArticleResourcePrimKeys, kbArticle.getParentResourcePrimKey(),
 			kbArticle.getParentResourcePrimKey());
 
-		long kbFolderClassNameId = _portal.getClassNameId(
-			KBFolderConstants.getClassName());
-
 		if (kbArticle.getParentResourcePrimKey() !=
 				KBFolderConstants.DEFAULT_PARENT_FOLDER_ID) {
 


### PR DESCRIPTION
Relevant tickets:

https://issues.liferay.com/browse/LPP-30548
https://issues.liferay.com/browse/LPS-83064

I'm sending this directly to you, Tamas, as we're trying to follow a new workflow for Staging issues here.

The code for determining the parentResourceClassName for imported KBArticles is incorrect because it relies on guessing based on existing classPK's (regardless of site). It's unlikely, but this can cause issues with imports when folders (or possibly articles) in other sites have the expected value, even though it should be remapped to a new value after the import.

I tried to remove some of the confusing logic with this, by leveraging the existing reference import method from `BaseStagedModelDataHandler`. I don't think this would cause problems -- but if there is some problem with this I didn't see, please let me know. Thank you!