### PR TITLE
[TECHNICAL-SUPPORT] LPS-83187

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
@@ -2353,8 +2353,11 @@ public class StagingImpl implements Staging {
 		Map<String, String[]> parameterMap =
 			(Map<String, String[]>)settingsMap.get("parameterMap");
 
-		String backgroundTaskName = MapUtil.getString(
-			parameterMap, "name", exportImportConfiguration.getName());
+		String backgroundTaskName = exportImportConfiguration.getName();
+
+		if (Validator.isNull(backgroundTaskName)) {
+			MapUtil.getString(parameterMap, "name");
+		}
 
 		Map<String, Serializable> taskContextMap = new HashMap<>();
 
@@ -3491,8 +3494,11 @@ public class StagingImpl implements Staging {
 		Map<String, String[]> parameterMap =
 			(Map<String, String[]>)settingsMap.get("parameterMap");
 
-		String backgroundTaskName = MapUtil.getString(
-			parameterMap, "name", exportImportConfiguration.getName());
+		String backgroundTaskName = exportImportConfiguration.getName();
+
+		if (Validator.isNull(backgroundTaskName)) {
+			backgroundTaskName = MapUtil.getString(parameterMap, "name");
+		}
 
 		Map<String, Serializable> taskContextMap = new HashMap<>();
 


### PR DESCRIPTION
Relevant tickets:

https://issues.liferay.com/browse/LPP-30738
https://issues.liferay.com/browse/LPS-83187

Scheduled publishes based on a publish template do not use the configured name. This is because scheduled publishes in particular have their parameters directly copied from the template -- and since they include the title, that is prioritized over the one the user sets for the specific publish.

So, this fix is just an attempt to correct the priority, preferring the configured title for the specific publish over that of the template. Let me know if there are any problems with this I did not foresee, however. Thanks!