### PR TITLE
LPS-83187

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
@@ -2986,6 +2986,10 @@ public class StagingImpl implements Staging {
 			portletRequest, targetGroupId, false);
 		String name = ParamUtil.getString(portletRequest, "name");
 
+		if (!Validator.isBlank(name)) {
+			parameterMap.put("name", new String[] {name});
+		}
+
 		_layoutService.schedulePublishToLive(
 			sourceGroupId, targetGroupId, privateLayout, layoutIds,
 			parameterMap, scheduleInformation.getGroupName(),
@@ -3082,6 +3086,10 @@ public class StagingImpl implements Staging {
 		ScheduleInformation scheduleInformation = getScheduleInformation(
 			portletRequest, groupId, true);
 		String name = ParamUtil.getString(portletRequest, "name");
+
+		if (!Validator.isBlank(name)) {
+			parameterMap.put("name", new String[] {name});
+		}
 
 		_layoutService.schedulePublishToRemote(
 			groupId, privateLayout, layoutIdMap, parameterMap, remoteAddress,


### PR DESCRIPTION
Resent from: https://github.com/moltam89/liferay-portal/pull/429

Relevant tickets:

https://issues.liferay.com/browse/LPP-30738
https://issues.liferay.com/browse/LPS-83187

> Scheduled publishes based on a publish template do not use the configured name. This is because scheduled publishes in particular have their parameters directly copied from the template -- and since they include the title, that is prioritized over the one the user sets for the specific publish.

Implemented the changes [suggested here](https://github.com/moltam89/liferay-portal/pull/429#issuecomment-403453015) (changing the parameterMap when the publish is scheduled, rather than overriding it when it is executed, more like LPS-64810: https://github.com/brianchandotcom/liferay-portal/pull/38514/commits/f63a2555296ed8a15eee1942290f67895bdb2ddb).

When implementing it this way, there is one case I was not totally sure about; there is also this method, for scheduling page copies from live: https://github.com/liferay/liferay-portal/blob/master/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java#L2912

I looked at it, and it seems like it would be possible to make the same change in the code, but I was not sure how to test this because I'm not sure how one does a copy from live. Furthermore, I'm not sure if that is something you can create a template for, so I don't know if this would even be applicable.

Do you think this looks good? Let me know if you see any more problems with this. Thank you!