### PR TITLE
LPS-83426

### DIFF
--- a/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
+++ b/modules/apps/document-library/document-library-web/src/main/java/com/liferay/document/library/web/internal/display/context/DLAdminManagementToolbarDisplayContext.java
@@ -105,7 +105,10 @@ public class DLAdminManagementToolbarDisplayContext {
 
 				boolean stagedActions = false;
 
-				if (!scopeGroup.isStaged() || scopeGroup.isStagingGroup() ||
+				if ((!scopeGroup.hasRemoteStagingGroup() &&
+					 !scopeGroup.isStaged()) ||
+					scopeGroup.isStagedRemotely() ||
+					scopeGroup.isStagingGroup() ||
 					!scopeGroup.isStagedPortlet(
 						DLPortletKeys.DOCUMENT_LIBRARY)) {
 


### PR DESCRIPTION
Relevant tickets:

https://issues.liferay.com/browse/LPP-30810
https://issues.liferay.com/browse/LPS-83426

**Fix explanation:**
When remote Staging is enabled between two sites, documents on the Staging site, when selected from content administration, no longer have most actions available. This is because there is a check in `DLAdminManagementToolbarDisplayContext` that attempts to restrict these actions from being taken on the live site in the case of Staging, but it does not work properly (and in fact has the opposite of the intended effect).

This happens because, since `liveGroupId` is not set for remote Staging (only local live Staging), the `isStagingGroup()` method returns false for the Staging group, and `isStaged()` also returns false for the live group. To me, this seems confusing, but it does seem to be this way for all versions (master/DXP all the way back to 6.2), so I'm not sure we can say it's a bug (and I could imagine it causing regressions if it were changed, as a lot of things rely on those methods). It does mean the logic in cases like this looks very confusing, however.

**Thoughts on an alternative fix:**
There is also one other peculiarity with this code: for some reason, only the DL admin portlet cares about Staging, and none of the others do. This seems to be code that was carried over from a long time ago (see [LPS-20939](https://issues.liferay.com/browse/LPS-20939)), but was not applied to other components. So, another approach could be to simply remove the Staging-related code from here. 

However, after doing some testing with other portlets, I am starting to think the opposite, and that in fact the other portlets should have this code, as well. For other portlets, the actions are always available -- but when the user attempts most of them, they get a vague permissions error, and the results are often confusing (see a screenshot I attached to the LPS for an attempt to move a WC article on the live site; it gives the permissions error but gives the dialog box as though you could still move the article).

Thus, I think we should simply fix the checks for this case -- and possibly even look to adding some for the other portlets. Let me know if you disagree, though, or if there's anything else I've overlooked. Thanks in advance!