### PR TITLE
[TECHNICAL-SUPPORT] LPS-84308

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
@@ -1539,11 +1539,21 @@ public class LayoutStagedModelDataHandler
 			return;
 		}
 
+		boolean privateLayout = portletDataContext.isPrivateLayout();
+		long scopeGroupId = portletDataContext.getScopeGroupId();
+
+		Layout existingLayout = _layoutLocalService.fetchLayout(
+			linkedToLayoutUuid, scopeGroupId, privateLayout);
+
+		if (existingLayout != null) {
+			typeSettingsProperties.setProperty(
+				"linkToLayoutId", String.valueOf(existingLayout.getLayoutId()));
+		}
+
 		_exportImportProcessCallbackRegistry.registerCallback(
 			portletDataContext.getExportImportProcessId(),
 			new ImportLinkedLayoutCallable(
-				portletDataContext.getScopeGroupId(),
-				portletDataContext.isPrivateLayout(), importedLayout.getUuid(),
+				scopeGroupId, privateLayout, importedLayout.getUuid(),
 				linkedToLayoutUuid));
 	}
 


### PR DESCRIPTION
Relevant tickets:

https://issues.liferay.com/browse/LPP-31138
https://issues.liferay.com/browse/LPS-84308

Link to pages link to the incorrect page when a long Staging publication is taking place (typically later in the publication, after the halfway point). This is because during the publication, the typeSettings are directly copied from the Staging site to propagate any changes (which have different layoutIds), before they are corrected again with the new Site's mapping of layoutIds.

The fix is simply adding a check for whether the correct layoutId is already known, so we can fix it beforehand without reintroducing any broken links.

Please let me know if there are any problems with this, or if there is something I overlooked. Thank you!