### PR TITLE
GROW-495 When creating a new page, the focus should be at the title field automatically

### DIFF
--- a/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/edit_page.jsp
+++ b/modules/apps/wiki/wiki-web/src/main/resources/META-INF/resources/wiki/edit_page.jsp
@@ -412,6 +412,14 @@ if (portletTitleBasedNavigation) {
 		}
 	);
 </aui:script>
+<script>
+setTimeout(
+		function() 
+		{
+			$("#<portlet:namespace />titleEditor").focus();
+		}
+		, 1000);
+</script>
 
 <%
 if ((wikiPage != null) && !wikiPage.isNew()) {


### PR DESCRIPTION
Hi,

I have tried to listen for multiple events,then set the focus on the editor element but it did not work.
I have also tried to change the title to regular input field, instead of editor field. The focus worked, but it changed the CSS of the field completely.

Finally I have found this solution. I know, this approach is not the best, but it works. 

I hope this will not be merged to the master branch, but it is fine for fixing this GROW issue.

Thanks,
László