### PR TITLE
LPS-86368

### DIFF
--- a/portal-impl/src/com/liferay/portlet/documentlibrary/service/persistence/impl/DLFileEntryPersistenceImpl.java
+++ b/portal-impl/src/com/liferay/portlet/documentlibrary/service/persistence/impl/DLFileEntryPersistenceImpl.java
@@ -20,6 +20,7 @@ import com.liferay.document.library.kernel.exception.NoSuchFileEntryException;
 import com.liferay.document.library.kernel.model.DLFileEntry;
 import com.liferay.document.library.kernel.service.persistence.DLFileEntryPersistence;
 
+import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
 import com.liferay.petra.string.StringBundler;
 
 import com.liferay.portal.kernel.bean.BeanReference;
@@ -49,6 +50,7 @@ import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
 
 import com.liferay.portlet.documentlibrary.model.impl.DLFileEntryImpl;
 import com.liferay.portlet.documentlibrary.model.impl.DLFileEntryModelImpl;
+import com.liferay.portlet.exportimport.staging.StagingAdvicesThreadLocal;
 
 import java.io.Serializable;
 
@@ -14871,7 +14873,9 @@ public class DLFileEntryPersistenceImpl extends BasePersistenceImpl<DLFileEntry>
 			}
 		}
 
-		if (!dlFileEntryModelImpl.hasSetModifiedDate()) {
+		if (!dlFileEntryModelImpl.hasSetModifiedDate() &&
+			!ExportImportThreadLocal.isImportInProcess()) {
+
 			if (serviceContext == null) {
 				dlFileEntry.setModifiedDate(now);
 			}


### PR DESCRIPTION
Relevant tickets:

https://issues.liferay.com/browse/LPP-31765
https://issues.liferay.com/browse/LPS-86368

If a document is published to live (or imported) that has had more than one version increment since the last time, then the modified date for the DLFileEntry in the database (in the DLFileEntry table) will be updated with the current timestamp, instead of the date the document was actually modified. This is because, Liferay treats subsequent imported versions as updates, and while the modifiedDate was technically updated at the time of the document update (so before the export), it did not happen during the "update," so it assumes the modifiedDate still needs to be changed.

This change simply excludes imports from this update, because in these cases the modifiedDate should have already been changed. Please let me know if you think there is anything about this I may have overlooked, however. Thanks in advance!