### PR TITLE
Ricky pan lps 85960

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/LayoutReferencesExportImportContentProcessor.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/content/processor/LayoutReferencesExportImportContentProcessor.java
@@ -261,6 +261,7 @@ public class LayoutReferencesExportImportContentProcessor
 
 			if (url.endsWith(StringPool.SLASH)) {
 				url = url.substring(0, url.length() - 1);
+				endPos--;
 			}
 
 			StringBundler urlSB = new StringBundler(6);

--- a/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/DefaultExportImportContentProcessorTest.java
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/java/com/liferay/exportimport/internal/content/processor/test/DefaultExportImportContentProcessorTest.java
@@ -525,6 +525,21 @@ public class DefaultExportImportContentProcessorTest {
 	}
 
 	@Test
+	public void testExportLinksToURLSWithStopCharacters() throws Exception {
+		String path = RandomTestUtil.randomString();
+
+		String content = getContent("url_links.txt");
+
+		content = content.replaceAll("PATH", path);
+
+		content = _exportImportContentProcessor.replaceExportContentReferences(
+			_portletDataContextExport, _referrerStagedModel, content, true,
+			true);
+
+		_assertContainsPathWithStopCharacters(content, path);
+	}
+
+	@Test
 	public void testExportLinksToUserLayouts() throws Exception {
 		User user = TestPropsValues.getUser();
 
@@ -1158,6 +1173,24 @@ public class DefaultExportImportContentProcessorTest {
 			entriesStream.anyMatch(pattern.asPredicate()));
 	}
 
+	private void _assertContainsPathWithStopCharacters(
+		String content, String path) {
+
+		for (char stopChar : _LAYOUT_REFERENCE_STOP_CHARS) {
+			StringBundler sb = new StringBundler(4);
+
+			sb.append(path);
+			sb.append(StringPool.SLASH);
+			sb.append(stopChar);
+			sb.append(StringPool.SLASH);
+
+			Assert.assertTrue(
+				String.format(
+					"%s does not contain the path %s", content,
+					sb.toString()), content.contains(sb.toString()));
+		}
+	}
+
 	private void _assertContainsReference(
 		List<String> entries, String className, long classPK) {
 
@@ -1181,6 +1214,13 @@ public class DefaultExportImportContentProcessorTest {
 	private static final String[] _GROUP_FRIENDLY_URL_VARIABLES = {
 		"[$GROUP_FRIENDLY_URL$]", "[$PRIVATE_LAYOUT_FRIENDLY_URL$]",
 		"[$PUBLIC_LAYOUT_FRIENDLY_URL$]"
+	};
+
+	private static final char[] _LAYOUT_REFERENCE_STOP_CHARS = {
+		CharPool.APOSTROPHE, CharPool.CLOSE_BRACKET, CharPool.CLOSE_CURLY_BRACE,
+		CharPool.CLOSE_PARENTHESIS, CharPool.GREATER_THAN, CharPool.LESS_THAN,
+		CharPool.PIPE, CharPool.POUND, CharPool.QUESTION, CharPool.QUOTE,
+		CharPool.SPACE
 	};
 
 	private static final String[] _MULTI_LOCALE_LAYOUT_VARIABLES = {

--- a/modules/apps/export-import/export-import-test/src/testIntegration/resources/com/liferay/exportimport/internal/content/processor/test/dependencies/url_links.txt
+++ b/modules/apps/export-import/export-import-test/src/testIntegration/resources/com/liferay/exportimport/internal/content/processor/test/dependencies/url_links.txt
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+
+<root available-locales="en_US" default-locale="en_US">
+	<dynamic-element name="content" type="text_area" index-type="text" instance-id="qnll">
+		<dynamic-content language-id="en_US"><![CDATA[<p>&lt;a href="https://DOMAIN/PATH/'/" target="_blank"&gt;Link on html&lt;/a&gt;</p>]]></dynamic-content>
+		<dynamic-content language-id="en_US"><![CDATA[<p>&lt;a href="https://DOMAIN/PATH/]/" target="_blank"&gt;Link on html&lt;/a&gt;</p>]]></dynamic-content>
+		<dynamic-content language-id="en_US"><![CDATA[<p>&lt;a href="https://DOMAIN/PATH/}/" target="_blank"&gt;Link on html&lt;/a&gt;</p>]]></dynamic-content>
+		<dynamic-content language-id="en_US"><![CDATA[<p>&lt;a href="https://DOMAIN/PATH/)/" target="_blank"&gt;Link on html&lt;/a&gt;</p>]]></dynamic-content>
+		<dynamic-content language-id="en_US"><![CDATA[<p>&lt;a href="https://DOMAIN/PATH/>/" target="_blank"&gt;Link on html&lt;/a&gt;</p>]]></dynamic-content>
+		<dynamic-content language-id="en_US"><![CDATA[<p>&lt;a href="https://DOMAIN/PATH/</" target="_blank"&gt;Link on html&lt;/a&gt;</p>]]></dynamic-content>
+		<dynamic-content language-id="en_US"><![CDATA[<p>&lt;a href="https://DOMAIN/PATH/|/" target="_blank"&gt;Link on html&lt;/a&gt;</p>]]></dynamic-content>
+		<dynamic-content language-id="en_US"><![CDATA[<p>&lt;a href="https://DOMAIN/PATH/#/" target="_blank"&gt;Link on html&lt;/a&gt;</p>]]></dynamic-content>
+		<dynamic-content language-id="en_US"><![CDATA[<p>&lt;a href="https://DOMAIN/PATH/?/" target="_blank"&gt;Link on html&lt;/a&gt;</p>]]></dynamic-content>
+		<dynamic-content language-id="en_US"><![CDATA[<p>&lt;a href="https://DOMAIN/PATH/"/" target="_blank"&gt;Link on html&lt;/a&gt;</p>]]></dynamic-content>
+		<dynamic-content language-id="en_US"><![CDATA[<p>&lt;a href="https://DOMAIN/PATH/ /" target="_blank"&gt;Link on html&lt;/a&gt;</p>]]></dynamic-content>
+	</dynamic-element>
+</root>


### PR DESCRIPTION
/cc @ricky-pan @SamZiemer @alec-shay

Relevant tickets:

https://issues.liferay.com/browse/LPP-31595
https://issues.liferay.com/browse/LPS-85960

Hello Tamás,

Here is a Staging fix for the logic in LayoutReferencesExportImportContentProcessor from @ricky-pan complete with an integration test - let me know if there's anything else you need.

From Ricky:

> Issue: When staging, Liferay parses URLs in content to check for relative URLs within different environments and modifies them as needed to preserve links.The current implementation of URL parsing alters URLs by possibly removing a "/", thus breaking some links. This specifically can happen when a link has a "/#".
> 
> Solution: The endPos variable wasn't adjusted properly to replace the trailing "/"s, so I modified the counter.