### PR TITLE
[TECHNICAL-SUPPORT] LPS-86582

### DIFF
--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/exportimport/portlet/preferences/processor/JournalContentExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/exportimport/portlet/preferences/processor/JournalContentExportImportPortletPreferencesProcessor.java
@@ -294,7 +294,7 @@ public class JournalContentExportImportPortletPreferencesProcessor
 		portletDataContext.setScopeGroupId(groupId);
 
 		try {
-			if (Validator.isNotNull(articleId)) {
+			if (Validator.isNotNull(articleId) && (groupId != 0)) {
 				Group importedArticleGroup = _groupLocalService.getGroup(
 					groupId);
 


### PR DESCRIPTION
Relevant tickets:

https://issues.liferay.com/browse/LPP-31870
https://issues.liferay.com/browse/LPS-86582

Embedded Web Content display portlets may not include a groupId, but there is no check for this in the code, so it may cause an error in publishing. This causes any publish containing those portlets to fail (because the Group with ID 0 is not found).

Note that in master, the Exception still occurs because of this, but it does not occur in the UI and the publish still appears overall successful. However I think the fact that it still throws this Exception is wrong, and we should try to keep the versions the same, so I think this is still the correct fix.

Please let me know if you have any thoughts or concerns about this. Thank you!