### PR TITLE
[TECHNICAL-SUPPORT] LPS-86818

### DIFF
--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/publish/publish_layouts.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/publish/publish_layouts.jsp
@@ -197,7 +197,9 @@ response.setHeader("Ajax-ID", request.getHeader("Ajax-ID"));
 
 					int incompleteBackgroundTaskCount = BackgroundTaskManagerUtil.getBackgroundTasksCount(stagingGroupId, taskExecutorClassName, false);
 
-					incompleteBackgroundTaskCount += BackgroundTaskManagerUtil.getBackgroundTasksCount(liveGroupId, taskExecutorClassName, false);
+					if (localPublishing) {
+						incompleteBackgroundTaskCount += BackgroundTaskManagerUtil.getBackgroundTasksCount(liveGroupId, taskExecutorClassName, false);
+					}
 					%>
 
 					<div class="<%= (incompleteBackgroundTaskCount == 0) ? "hide" : "in-progress" %>" id="<portlet:namespace />incompleteProcessMessage">

--- a/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/publish/simple/publish_layouts_simple.jsp
+++ b/modules/apps/export-import/export-import-web/src/main/resources/META-INF/resources/publish/simple/publish_layouts_simple.jsp
@@ -84,7 +84,9 @@ Map<String, String[]> parameterMap = (Map<String, String[]>)settingsMap.get("par
 
 		int incompleteBackgroundTaskCount = BackgroundTaskManagerUtil.getBackgroundTasksCount(groupDisplayContextHelper.getStagingGroupId(), taskExecutorClassName, false);
 
-		incompleteBackgroundTaskCount += BackgroundTaskManagerUtil.getBackgroundTasksCount(groupDisplayContextHelper.getLiveGroupId(), taskExecutorClassName, false);
+		if (localPublishing) {
+			incompleteBackgroundTaskCount += BackgroundTaskManagerUtil.getBackgroundTasksCount(groupDisplayContextHelper.getLiveGroupId(), taskExecutorClassName, false);
+		}
 		%>
 
 		<div class="container-fluid-1280">


### PR DESCRIPTION
/cc @jonathanmccann

Relevant ticket:

https://issues.liferay.com/browse/LPS-86818

From Jonathan:

> When staging remotely, the `stagingGroupId` and the `liveGroupId` are the same thus doubling the real amount of staging processes currently queued.

Please let us know if you have any thoughts or concerns on this. Thanks!