### PR TITLE
LPS-88233 Revert "LPS-82958 Keep consistency between export and import order"

### DIFF
--- a/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/exportimport/data/handler/StagedGroupStagedModelDataHandler.java
+++ b/modules/apps/site/site-impl/src/main/java/com/liferay/site/internal/exportimport/data/handler/StagedGroupStagedModelDataHandler.java
@@ -310,14 +310,6 @@ public class StagedGroupStagedModelDataHandler
 				portletDataContext.getManifestSummary());
 		}
 
-		// Import site data portlets
-
-		if (_log.isDebugEnabled() && !sitePortletElements.isEmpty()) {
-			_log.debug("Importing portlets");
-		}
-
-		importSitePortlets(portletDataContext, sitePortletElements);
-
 		// Import services
 
 		Element siteServicesElement = rootElement.element("site-services");
@@ -340,6 +332,14 @@ public class StagedGroupStagedModelDataHandler
 			StagedModelDataHandlerUtil.importStagedModel(
 				portletDataContext, groupElement);
 		}
+
+		// Import site data portlets
+
+		if (_log.isDebugEnabled() && !sitePortletElements.isEmpty()) {
+			_log.debug("Importing portlets");
+		}
+
+		importSitePortlets(portletDataContext, sitePortletElements);
 	}
 
 	protected void exportPortlet(


### PR DESCRIPTION
Hi @moltam89 ,

Can you please review this and forward if ok?

The reasoning behind the revert is that site data portlets can reference the imported group's layouts, so importing those before the data portlets is a must.

thanks,
