### PR TITLE
[TECHNICAL-SUPPORT] LPS-89918

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/controller/LayoutImportController.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/controller/LayoutImportController.java
@@ -1372,6 +1372,14 @@ public class LayoutImportController implements ImportController {
 				continue;
 			}
 
+			boolean globalLayoutPrototype = GetterUtil.getBoolean(
+				layoutElement.attributeValue(
+					"global-layout-prototype", "true"));
+
+			if (!globalLayoutPrototype) {
+				continue;
+			}
+
 			String layoutPrototypeUuid = GetterUtil.getString(
 				layoutElement.attributeValue("layout-prototype-uuid"));
 

--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
@@ -40,6 +40,7 @@ import com.liferay.fragment.service.FragmentEntryLinkLocalService;
 import com.liferay.layout.admin.web.internal.exportimport.data.handler.util.LayoutPageTemplateStructureDataHandlerUtil;
 import com.liferay.layout.constants.LayoutConstants;
 import com.liferay.layout.page.template.model.LayoutPageTemplateStructure;
+import com.liferay.layout.page.template.service.LayoutPageTemplateEntryLocalService;
 import com.liferay.layout.page.template.service.LayoutPageTemplateStructureLocalService;
 import com.liferay.petra.reflect.ReflectionUtil;
 import com.liferay.petra.string.CharPool;
@@ -270,6 +271,27 @@ public class LayoutStagedModelDataHandler
 		populateElementLayoutMetadata(layoutElement, layout);
 
 		layoutElement.addAttribute(Constants.ACTION, Constants.ADD);
+
+		String layoutPrototypeUuid = layout.getLayoutPrototypeUuid();
+
+		if (Validator.isNotNull(layoutPrototypeUuid)) {
+			LayoutPrototype layoutPrototype =
+				_layoutPrototypeLocalService.
+					getLayoutPrototypeByUuidAndCompanyId(
+						layoutPrototypeUuid, layout.getCompanyId());
+
+			boolean globalTemplate = false;
+
+			Group companyGroup = _groupLocalService.getCompanyGroup(
+				layoutPrototype.getCompanyId());
+
+			if (layoutPrototype.getGroupId() == companyGroup.getGroupId()) {
+				globalTemplate = true;
+			}
+
+			layoutElement.addAttribute(
+				"global-layout-prototype", String.valueOf(globalTemplate));
+		}
 
 		portletDataContext.setPlid(layout.getPlid());
 
@@ -2034,6 +2056,10 @@ public class LayoutStagedModelDataHandler
 	private LayoutFriendlyURLLocalService _layoutFriendlyURLLocalService;
 	private LayoutLocalService _layoutLocalService;
 	private LayoutLocalServiceHelper _layoutLocalServiceHelper;
+
+	@Reference
+	private LayoutPageTemplateEntryLocalService
+		_layoutPageTemplateEntryLocalService;
 
 	@Reference
 	private LayoutPageTemplateStructureDataHandlerUtil


### PR DESCRIPTION
Relevant tickets:

https://issues.liferay.com/browse/LPP-32655
https://issues.liferay.com/browse/LPS-89918

If a site or site template contains a page template with one or more pages based on it, then they cannot all be imported into another site with a single import, despite all being present in the LAR.

This occurs because of a validation step that occurs for all page templates, which was necessary in previous versions when page templates could not be scoped to the site, but is now unnecessary since they can be included in the same import.

As discussed on [PTR-566](https://issues.liferay.com/browse/PTR-566), although it's not the most robust solution, we are for now going with a solution of adding a flag for layouts on import to skip template validation if they are not based on a Global page template, since it should not be essential for them, anyway.

Hopefully this is about what you were thinking. Please let me know if there are any more concerns with this that you can see. Thank you.