### PR TITLE
[TECHNICAL-SUPPORT] LPS-90924 Changes during page revision workflow are not applied

### DIFF
--- a/portal-impl/src/com/liferay/portal/service/impl/PortletPreferencesLocalServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/PortletPreferencesLocalServiceImpl.java
@@ -750,6 +750,11 @@ public class PortletPreferencesLocalServiceImpl
 		}
 
 		try {
+			boolean hasWorkflowTask = StagingUtil.hasWorkflowTask(
+				serviceContext.getUserId(), layoutRevision);
+
+			serviceContext.setAttribute("revisionInProgress", hasWorkflowTask);
+
 			layoutRevision = layoutRevisionLocalService.updateLayoutRevision(
 				serviceContext.getUserId(),
 				layoutRevision.getLayoutRevisionId(),


### PR DESCRIPTION
Hi @moltam89 ,

As mentioned in the [PTR](https://issues.liferay.com/browse/PTR-558?focusedCommentId=1684071&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-1684071), `"revisionInProgress"` variable in ServiceContext is set to true in  [LayoutLocalServiceStagingAdvice](https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/service/impl/LayoutLocalServiceStagingAdvice.java#L299) and based on this, [LayoutRevisionLocalServiceImpl.updateLayoutRevision(..)](https://github.com/liferay/liferay-portal/blob/master/portal-impl/src/com/liferay/portal/service/impl/LayoutRevisionLocalServiceImpl.java#L474) decides whether to create a new LayoutRevision or update the existing one. In our case, it should update the LayoutRevision under review.
The problem is that this doesn't work, when the reviewer is only changing the settings of the portlets in the Layout. To make sure that `"revisionInProgress"` is true, it should be set when updating portlet configurations as well (only when the portlet is on a Layout that is under review in the page versioning workflow).

Please review my changes.

Thanks,
Vendel