### PR TITLE
LPS-90347 Prevent archived setups from purging journalContentSearch

### DIFF
--- a/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/exportimport/portlet/preferences/processor/JournalContentExportImportPortletPreferencesProcessor.java
+++ b/modules/apps/journal/journal-content-web/src/main/java/com/liferay/journal/content/web/internal/exportimport/portlet/preferences/processor/JournalContentExportImportPortletPreferencesProcessor.java
@@ -48,8 +48,10 @@ import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.workflow.WorkflowConstants;
+import com.liferay.portlet.PortletPreferencesImpl;
 
 import java.util.List;
 import java.util.Map;
@@ -348,7 +350,17 @@ public class JournalContentExportImportPortletPreferencesProcessor
 						}
 					}
 
-					if (portletDataContext.getPlid() > 0) {
+					int prefOwnerType = -1;
+
+					if (portletPreferences instanceof PortletPreferencesImpl) {
+						prefOwnerType =
+							((PortletPreferencesImpl)portletPreferences).
+								getOwnerType();
+					}
+
+					if ((portletDataContext.getPlid() > 0) && (prefOwnerType !=
+							PortletKeys.PREFS_OWNER_TYPE_ARCHIVED)) {
+
 						Layout layout = _layoutLocalService.fetchLayout(
 							portletDataContext.getPlid());
 


### PR DESCRIPTION
Hi @moltam89 ,
https://issues.liferay.com/browse/LPS-90347

As we discussed in person, leaving the portletDataContext check would reduce the chance of regression.

Can you please review?

Thanks,