### PR TITLE
[TECHNICAL-SUPPORT] LPS-89294

### DIFF
--- a/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/init.jsp
@@ -41,6 +41,7 @@ page import="com.liferay.portal.kernel.dao.search.SearchContainer" %><%@
 page import="com.liferay.portal.kernel.exception.NoSuchGroupException" %><%@
 page import="com.liferay.portal.kernel.exception.NoSuchLayoutException" %><%@
 page import="com.liferay.portal.kernel.exception.NoSuchRoleException" %><%@
+page import="com.liferay.portal.kernel.exception.PortalException" %><%@
 page import="com.liferay.portal.kernel.exception.RemoteOptionsException" %><%@
 page import="com.liferay.portal.kernel.language.LanguageUtil" %><%@
 page import="com.liferay.portal.kernel.language.UnicodeLanguageUtil" %><%@
@@ -58,8 +59,10 @@ page import="com.liferay.portal.kernel.scheduler.messaging.SchedulerResponse" %>
 page import="com.liferay.portal.kernel.security.auth.AuthException" %><%@
 page import="com.liferay.portal.kernel.security.auth.RemoteAuthException" %><%@
 page import="com.liferay.portal.kernel.security.permission.ActionKeys" %><%@
+page import="com.liferay.portal.kernel.service.GroupLocalServiceUtil" %><%@
 page import="com.liferay.portal.kernel.service.LayoutLocalServiceUtil" %><%@
 page import="com.liferay.portal.kernel.service.permission.GroupPermissionUtil" %><%@
+page import="com.liferay.portal.kernel.servlet.SessionErrors" %><%@
 page import="com.liferay.portal.kernel.servlet.SessionMessages" %><%@
 page import="com.liferay.portal.kernel.util.CalendarFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.util.Constants" %><%@
@@ -71,6 +74,7 @@ page import="com.liferay.portal.kernel.util.ParamUtil" %><%@
 page import="com.liferay.portal.kernel.util.PortalUtil" %><%@
 page import="com.liferay.portal.kernel.util.PortletKeys" %><%@
 page import="com.liferay.portal.kernel.util.StringUtil" %><%@
+page import="com.liferay.portal.kernel.util.UnicodeProperties" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.portal.kernel.util.WebKeys" %><%@
 page import="com.liferay.portal.util.PropsValues" %><%@
@@ -110,6 +114,8 @@ page import="javax.portlet.PortletURL" %>
 <%
 PortalPreferences portalPreferences = PortletPreferencesFactoryUtil.getPortalPreferences(liferayPortletRequest);
 
+boolean secureConnection = false;
+
 Calendar calendar = CalendarFactoryUtil.getCalendar(timeZone, locale);
 
 int timeZoneOffset = timeZone.getOffset(calendar.getTimeInMillis());
@@ -119,6 +125,16 @@ PublishTemplatesDisplayContext publishTemplatesDisplayContext = new PublishTempl
 StagingProcessesWebDisplayContext stagingProcessesWebDisplayContext = new StagingProcessesWebDisplayContext(renderResponse, request);
 
 StagingProcessesWebToolbarDisplayContext stagingProcessesWebToolbarDisplayContext = new StagingProcessesWebToolbarDisplayContext(request, pageContext, liferayPortletResponse);
+
+UnicodeProperties groupTypeSettingsProperties = GroupLocalServiceUtil.getGroup(portletGroupId).getTypeSettingsProperties();
+
+long remoteGroupId = GetterUtil.getLong(groupTypeSettingsProperties.getProperty("remoteGroupId"));
+
+int remotePort = GetterUtil.getInteger(groupTypeSettingsProperties.getProperty("remotePort"));
+
+String remoteAddress = groupTypeSettingsProperties.getProperty("remoteAddress");
+
+String remotePathContext = groupTypeSettingsProperties.getProperty("remotePathContext");
 %>
 
 <%@ include file="/init-ext.jsp" %>

--- a/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/navigation.jsp
+++ b/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/navigation.jsp
@@ -35,6 +35,15 @@ else {
 }
 
 String searchContainerId = "publishLayoutProcesses";
+
+try {
+	GroupLocalServiceUtil.validateRemote(portletGroupId, remoteAddress, remotePort, remotePathContext, secureConnection, remoteGroupId);
+}
+catch (PortalException e) {
+	if (e instanceof RemoteExportException) {
+		SessionErrors.add(renderRequest, e.getClass(), e);
+	}
+}
 %>
 
 <clay:navigation-bar

--- a/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/processes_list/view.jsp
+++ b/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/processes_list/view.jsp
@@ -24,6 +24,15 @@ String navigation = ParamUtil.getString(request, "navigation", "all");
 String orderByCol = ParamUtil.getString(request, "orderByCol");
 String orderByType = ParamUtil.getString(request, "orderByType");
 String searchContainerId = ParamUtil.getString(request, "searchContainerId");
+
+try {
+	GroupLocalServiceUtil.validateRemote(portletGroupId, remoteAddress, remotePort, remotePathContext, secureConnection, remoteGroupId);
+}
+catch (PortalException e) {
+	if (e instanceof RemoteExportException && (resourceRequest != null)) {
+		SessionErrors.add(resourceRequest, e.getClass(), e);
+	}
+}
 %>
 
 <liferay-ui:success key="localStagingEnabled" message="local-staging-is-successfully-enabled" />

--- a/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/scheduled_list/view.jsp
+++ b/modules/apps/staging/staging-processes-web/src/main/resources/META-INF/resources/scheduled_list/view.jsp
@@ -17,5 +17,6 @@
 <%@ include file="/init.jsp" %>
 
 <div class="container-fluid-1280" id="<portlet:namespace />scheduledProcessesContainer">
+	<%@ include file="/error/error_remote_export_exception.jspf" %>
 	<liferay-util:include page="/scheduled_list/scheduled_publish_processes.jsp" servletContext="<%= application %>" />
 </div>

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/service_http.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/service_http.ftl
@@ -13,6 +13,10 @@ import com.liferay.portal.kernel.service.http.TunnelUtil;
 import com.liferay.portal.kernel.util.MethodHandler;
 import com.liferay.portal.kernel.util.MethodKey;
 
+<#if stringUtil.equals(entity.name, "Group")>
+	import java.net.ConnectException;
+</#if>
+
 /**
  * Provides the HTTP utility for the
  * <code>${apiPackagePath}.service.${entity.name}ServiceUtil</code> service
@@ -139,6 +143,9 @@ public class ${entity.name}ServiceHttp {
 					<#if stringUtil.equals(entity.name, "Group")
 							&& (stringUtil.equals(method.name, "checkRemoteStagingGroup")
 							|| stringUtil.equals(method.name, "getGroupDisplayURL"))>
+						if (!(se.getCause() instanceof ConnectException)) {
+						_log.error(se, se);
+						}
 					<#else>
 						_log.error(se, se);
 					</#if>

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/service_http.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/service_http.ftl
@@ -136,7 +136,12 @@ public class ${entity.name}ServiceHttp {
 					</#if>
 				}
 				catch (com.liferay.portal.kernel.exception.SystemException se) {
-					_log.error(se, se);
+					<#if stringUtil.equals(entity.name, "Group")
+							&& (stringUtil.equals(method.name, "checkRemoteStagingGroup")
+							|| stringUtil.equals(method.name, "getGroupDisplayURL"))>
+					<#else>
+						_log.error(se, se);
+					</#if>
 
 					throw se;
 				}

--- a/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/service_http.ftl
+++ b/modules/util/portal-tools-service-builder/src/main/resources/com/liferay/portal/tools/service/builder/dependencies/service_http.ftl
@@ -140,11 +140,9 @@ public class ${entity.name}ServiceHttp {
 					</#if>
 				}
 				catch (com.liferay.portal.kernel.exception.SystemException se) {
-					<#if stringUtil.equals(entity.name, "Group")
-							&& (stringUtil.equals(method.name, "checkRemoteStagingGroup")
-							|| stringUtil.equals(method.name, "getGroupDisplayURL"))>
+					<#if stringUtil.equals(entity.name, "Group") && (stringUtil.equals(method.name, "checkRemoteStagingGroup") || stringUtil.equals(method.name, "getGroupDisplayURL"))>
 						if (!(se.getCause() instanceof ConnectException)) {
-						_log.error(se, se);
+							_log.error(se, se);
 						}
 					<#else>
 						_log.error(se, se);

--- a/portal-impl/src/com/liferay/portal/service/http/GroupServiceHttp.java
+++ b/portal-impl/src/com/liferay/portal/service/http/GroupServiceHttp.java
@@ -24,6 +24,8 @@ import com.liferay.portal.kernel.service.http.TunnelUtil;
 import com.liferay.portal.kernel.util.MethodHandler;
 import com.liferay.portal.kernel.util.MethodKey;
 
+import java.net.ConnectException;
+
 /**
  * Provides the HTTP utility for the
  * <code>GroupServiceUtil</code> service
@@ -220,7 +222,9 @@ public class GroupServiceHttp {
 			}
 		}
 		catch (com.liferay.portal.kernel.exception.SystemException se) {
-			_log.error(se, se);
+			if (!(se.getCause() instanceof ConnectException)) {
+				_log.error(se, se);
+			}
 
 			throw se;
 		}
@@ -424,7 +428,9 @@ public class GroupServiceHttp {
 			return (String)returnObj;
 		}
 		catch (com.liferay.portal.kernel.exception.SystemException se) {
-			_log.error(se, se);
+			if (!(se.getCause() instanceof ConnectException)) {
+				_log.error(se, se);
+			}
 
 			throw se;
 		}


### PR DESCRIPTION
/cc @gregory-bretall

Relevant tickets:

https://issues.liferay.com/browse/LPP-32794
https://issues.liferay.com/browse/LPS-89294

Re-sent from https://github.com/moltam89/liferay-portal/pull/477 with changes

Can you take a look at this for us again? Thank you!

Notes from @knchau from the previous pull:

> The issue was that the log error was being thrown on the console. I swallowed the log error if it was a ConnectException and displayed a UI error instead. I had to throw a RemoteExportException to display the proper banner by validating if the remote server is still live. If the connection is severed, it would throw a RemoteExportException for each tab and add a session error. I had to add session error for resourceRequest and renderRequest because the processes tab's view.jsp is called multiple times. renderRequest being used for the first call and resourceRequest for the calls thereafter. Scheduled tab's view.jsp includes the error file because processes tab handles the error message in its liferay-staging tag. The UI between the banner displays are different between the tabs because the processes tab has a management toolbar that has a margin-bottom which provides the gap between the toolbar and the banner whereas the scheduled tab only has the navigation toolbar which does not have any margins so there is no gap between that toolbar and the banner. The banners do not have any particular unique traits to provide a quick fix, so this is determined to be a separate issue.

And additionally:

> I have specified the changes to take effect on the two methods that printed the error logs.
> 
> The fix was to throw an exception when switching between tabs, resulting in a UI display that there is no connection to the remote server. The error log is swallowed from the change to the service_http template.