### PR TITLE
[TECHNICAL-SUPPORT] LPS-91909 Remove Cancel button for a running Staging publication

### DIFF
--- a/modules/apps/staging/staging-processes-web/src/main/java/com/liferay/staging/processes/web/internal/portlet/action/DeleteLayoutPublishBackgroundTaskMVCActionCommand.java
+++ b/modules/apps/staging/staging-processes-web/src/main/java/com/liferay/staging/processes/web/internal/portlet/action/DeleteLayoutPublishBackgroundTaskMVCActionCommand.java
@@ -14,6 +14,7 @@
 
 package com.liferay.staging.processes.web.internal.portlet.action;
 
+import com.liferay.portal.kernel.backgroundtask.BackgroundTask;
 import com.liferay.portal.kernel.backgroundtask.BackgroundTaskManager;
 import com.liferay.portal.kernel.exception.NoSuchBackgroundTaskException;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -51,7 +52,12 @@ public class DeleteLayoutPublishBackgroundTaskMVCActionCommand
 			actionRequest, "deleteBackgroundTaskIds");
 
 		for (long backgroundTaskId : backgroundTaskIds) {
-			_backgroundTaskManager.deleteBackgroundTask(backgroundTaskId);
+			BackgroundTask backgroundTask =
+				_backgroundTaskManager.getBackgroundTask(backgroundTaskId);
+
+			if (!backgroundTask.isInProgress()) {
+				_backgroundTaskManager.deleteBackgroundTask(backgroundTaskId);
+			}
 		}
 	}
 

--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/process_list_menu/items/delete.jspf
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/process_list_menu/items/delete.jspf
@@ -14,12 +14,14 @@
  */
 --%>
 
-<portlet:actionURL name="deleteBackgroundTasks" var="deleteBackgroundTaskURL">
-	<portlet:param name="redirect" value="<%= currentURL.toString() %>" />
-	<portlet:param name="deleteBackgroundTaskIds" value="<%= String.valueOf(backgroundTask.getBackgroundTaskId()) %>" />
-</portlet:actionURL>
+<c:if test="<%= !backgroundTask.isInProgress() %>">
+	<portlet:actionURL name="deleteBackgroundTasks" var="deleteBackgroundTaskURL">
+		<portlet:param name="redirect" value="<%= currentURL.toString() %>" />
+		<portlet:param name="deleteBackgroundTaskIds" value="<%= String.valueOf(backgroundTask.getBackgroundTaskId()) %>" />
+	</portlet:actionURL>
 
-<liferay-ui:icon
-	message="<%= deleteLabel %>"
-	url="<%= deleteBackgroundTaskURL %>"
-/>
+	<liferay-ui:icon
+		message="<%= deleteLabel %>"
+		url="<%= deleteBackgroundTaskURL %>"
+	/>
+</c:if>


### PR DESCRIPTION
Hi @moltam89 ,

I modified [delete.jspf](https://github.com/liferay/liferay-portal/blob/master/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/process_list_menu/items/delete.jspf#L22) based on [relaunch.jspf](https://github.com/liferay/liferay-portal/blob/master/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/process_list_menu/items/relaunch.jspf#L17) and [summary.jspf](https://github.com/liferay/liferay-portal/blob/master/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/process_list_menu/items/summary.jspf#L29) to hide the Delete/Cancel option when the staging process is in progress. It will still be shown for Scheduled and Finished ones.
As discussed, I also modified the back-end part, where the Cancel action actually gets processed. The modified [DeleteLayoutPublishBackgroundTaskMVCActionCommand](https://github.com/liferay/liferay-portal/blob/master/modules/apps/staging/staging-processes-web/src/main/java/com/liferay/staging/processes/web/internal/portlet/action/DeleteLayoutPublishBackgroundTaskMVCActionCommand.java#L59) will only delete/cancel those processes, that are not in progress.

Please review my changes.

Thanks,
Vendel