### PR TITLE
[TECHNICAL-SUPPORT] LPS-92285

### DIFF
--- a/modules/apps/user-groups-admin/user-groups-admin-impl/src/main/java/com/liferay/user/groups/admin/internal/exportimport/data/handler/UserGroupStagedModelDataHandler.java
+++ b/modules/apps/user-groups-admin/user-groups-admin-impl/src/main/java/com/liferay/user/groups/admin/internal/exportimport/data/handler/UserGroupStagedModelDataHandler.java
@@ -28,6 +28,7 @@ import com.liferay.portal.kernel.xml.Element;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -95,6 +96,25 @@ public class UserGroupStagedModelDataHandler
 		portletDataContext.addClassedModel(
 			userGroupElement, ExportImportPathUtil.getModelPath(userGroup),
 			userGroup);
+	}
+
+	@Override
+	protected void doImportMissingReference(
+			PortletDataContext portletDataContext, String uuid, long groupId,
+			long userGroupId)
+		throws Exception {
+
+		UserGroup existingUserGroup = fetchMissingReference(uuid, groupId);
+
+		if (existingUserGroup == null) {
+			return;
+		}
+
+		Map<Long, Long> userGroupIds =
+			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
+				UserGroup.class);
+
+		userGroupIds.put(userGroupId, existingUserGroup.getUserGroupId());
 	}
 
 	@Override


### PR DESCRIPTION
https://issues.liferay.com/browse/LPP-33306
https://issues.liferay.com/browse/LPS-92285

Hi Tamás,

Would you be able to take a look at this issue with user groups for us and let us know what you think? Note while the underlying issue just has to do with user groups imported as references, the steps to reproduce are using Audience Targeting, because it seems necessary to have simple steps for testing. Thanks in advance.

Notes from @joshuacords:

> Problem: UserGroup's DataModelStagedHandler doesn't have doImportMissingReference() implemented, so when Audience Targeting tries to import a User Segment based on a User Group it fails.
> 
> Solution: Implement the doImportMissingReference() method.
> 
> Note: The only way I have found to test this is on 7.1.x using Audience Targeting according to the instructions in WCM-1425. I could see needing a PTR to clarify if this implementation takes enough factors into account. I also made a new LPS ticket since the problem is not actually with Audience Targeting.