### PR TITLE
[TECHNICAL-SUPPORT] LPS-92039 Staging - Problems with creating Application Display Templates

### DIFF
--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/build.gradle
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/build.gradle
@@ -4,6 +4,7 @@ dependencies {
 	compileOnly group: "javax.portlet", name: "portlet-api", version: "3.0.0"
 	compileOnly group: "javax.servlet", name: "javax.servlet-api", version: "3.0.1"
 	compileOnly group: "org.osgi", name: "org.osgi.core", version: "5.0.0"
+	compileOnly project(":apps:staging:staging-api")
 	compileOnly project(":apps:static:osgi:osgi-util")
 	compileOnly project(":apps:static:portal-configuration:portal-configuration-metatype-api")
 	compileOnly project(":core:osgi-service-tracker-collections")

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/BaseDDMDisplay.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-api/src/main/java/com/liferay/dynamic/data/mapping/util/BaseDDMDisplay.java
@@ -42,6 +42,8 @@ import com.liferay.portal.kernel.util.ResourceBundleUtil;
 import com.liferay.portal.kernel.util.SetUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.staging.StagingGroupHelper;
+import com.liferay.staging.StagingGroupHelperUtil;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -407,7 +409,12 @@ public abstract class BaseDDMDisplay implements DDMDisplay {
 			return false;
 		}
 
-		if (!scopeGroup.hasLocalOrRemoteStagingGroup()) {
+		StagingGroupHelper stagingGroupHelper =
+			StagingGroupHelperUtil.getStagingGroupHelper();
+
+		if (!stagingGroupHelper.isLiveGroup(scopeGroup) ||
+			!stagingGroupHelper.isStagedPortlet(scopeGroup, portletId)) {
+
 			return true;
 		}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/display/context/DDMDisplayContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/display/context/DDMDisplayContext.java
@@ -739,9 +739,16 @@ public class DDMDisplayContext {
 			String resourceName)
 		throws PortalException {
 
+		if (getClassNameId() > 0) {
+			return PortletPermissionUtil.contains(
+				_ddmWebRequestHelper.getPermissionChecker(),
+				_ddmWebRequestHelper.getLayout(), resourceName,
+				ActionKeys.ADD_PORTLET_DISPLAY_TEMPLATE);
+		}
+
 		return PortletPermissionUtil.contains(
 			_ddmWebRequestHelper.getPermissionChecker(),
-			_ddmWebRequestHelper.getLayout(), resourceName,
+			_ddmWebRequestHelper.getScopeGroupId(), resourceName,
 			ActionKeys.ADD_PORTLET_DISPLAY_TEMPLATE);
 	}
 

--- a/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/display/context/DDMDisplayContext.java
+++ b/modules/apps/dynamic-data-mapping/dynamic-data-mapping-web/src/main/java/com/liferay/dynamic/data/mapping/web/internal/display/context/DDMDisplayContext.java
@@ -703,12 +703,11 @@ public class DDMDisplayContext {
 		long resourceClassNameId = PortalUtil.getClassNameId(
 			ddmDisplay.getStructureType());
 
-		if ((classNameId == 0) || (resourceClassNameId == 0)) {
-			return true;
-		}
+		ThemeDisplay themeDisplay = _ddmWebRequestHelper.getThemeDisplay();
 
-		ThemeDisplay themeDisplay = (ThemeDisplay)_renderRequest.getAttribute(
-			WebKeys.THEME_DISPLAY);
+		if ((classNameId == 0) || (resourceClassNameId == 0)) {
+			return ddmDisplay.isShowAddButton(themeDisplay.getScopeGroup());
+		}
 
 		if (ddmDisplay.isShowAddButton(themeDisplay.getScopeGroup()) &&
 			DDMTemplatePermission.containsAddTemplatePermission(


### PR DESCRIPTION
Hi @moltam89 ,

This change handles 2 problems in the following scenarios:
* Staging is active, ADT not staged: the `Add` button should appear on Staging and on Live site as well. It should also show all possible ADT types to create.
* Staging is active, ADT is staged: `Add` button should only appear on Staging site.

As discussed, I started using `StagingGroupHelper`, instead of the standard methods of `Group`. Also, simplified some of the code by retrieving `themeDisplay` and `scopeGroupId` directly.

Please review my changes.

Thanks,
Vendel