### PR TITLE
LPS-93315 (resend)

### DIFF
--- a/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
+++ b/modules/apps/export-import/export-import-service/src/main/java/com/liferay/exportimport/internal/staging/StagingImpl.java
@@ -2991,6 +2991,14 @@ public class StagingImpl implements Staging {
 					settingsMap, "privateLayout");
 				layoutIds = GetterUtil.getLongValues(
 					settingsMap.get("layoutIds"));
+
+				Map<String, String[]> requestParameterMap =
+					portletRequest.getParameterMap();
+
+				if (requestParameterMap.containsKey("timeZoneId")) {
+					parameterMap.put(
+						"timeZoneId", requestParameterMap.get("timeZoneId"));
+				}
 			}
 		}
 

--- a/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/QuartzTriggerFactory.java
+++ b/modules/apps/portal-scheduler/portal-scheduler-quartz/src/main/java/com/liferay/portal/scheduler/quartz/internal/QuartzTriggerFactory.java
@@ -22,6 +22,7 @@ import com.liferay.portal.kernel.scheduler.Trigger;
 import com.liferay.portal.kernel.scheduler.TriggerFactory;
 
 import java.util.Date;
+import java.util.TimeZone;
 
 import org.osgi.service.component.annotations.Component;
 
@@ -94,6 +95,19 @@ public class QuartzTriggerFactory implements TriggerFactory {
 		return createTrigger(
 			jobName, groupName, startDate, endDate,
 			CronScheduleBuilder.cronSchedule(cronExpression));
+	}
+
+	@Override
+	public Trigger createTrigger(
+		String jobName, String groupName, Date startDate, Date endDate,
+		TimeZone timeZone, String cronExpression) {
+
+		CronScheduleBuilder scheduleBuilder = CronScheduleBuilder.cronSchedule(
+			cronExpression);
+
+		return createTrigger(
+			jobName, groupName, startDate, endDate,
+			scheduleBuilder.inTimeZone(timeZone));
 	}
 
 	@Override

--- a/modules/apps/portal-scheduler/portal-scheduler/src/main/java/com/liferay/portal/scheduler/internal/SchedulerEngineHelperImpl.java
+++ b/modules/apps/portal-scheduler/portal-scheduler/src/main/java/com/liferay/portal/scheduler/internal/SchedulerEngineHelperImpl.java
@@ -52,6 +52,7 @@ import com.liferay.portal.kernel.util.InetAddressUtil;
 import com.liferay.portal.kernel.util.ObjectValuePair;
 import com.liferay.portal.kernel.util.ParamUtil;
 import com.liferay.portal.kernel.util.Portal;
+import com.liferay.portal.kernel.util.TimeZoneUtil;
 import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.scheduler.internal.configuration.SchedulerEngineHelperConfiguration;
 import com.liferay.portal.scheduler.internal.messaging.config.ScriptingMessageListener;
@@ -174,9 +175,15 @@ public class SchedulerEngineHelperImpl implements SchedulerEngineHelper {
 		Calendar recurrenceCalendar = null;
 
 		if (timeZoneSensitive) {
-			recurrenceCalendar = CalendarFactoryUtil.getCalendar();
+			String timeZoneId = ParamUtil.getString(
+				portletRequest, "timeZoneId");
 
-			recurrenceCalendar.setTime(calendar.getTime());
+			if (Validator.isNotNull(timeZoneId)) {
+				recurrenceCalendar = CalendarFactoryUtil.getCalendar(
+					TimeZoneUtil.getTimeZone(timeZoneId));
+
+				recurrenceCalendar.setTime(calendar.getTime());
+			}
 		}
 		else {
 			recurrenceCalendar = (Calendar)calendar.clone();

--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/input_scheduler/page.jsp
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/input_scheduler/page.jsp
@@ -64,7 +64,6 @@
 
 		int[] monthIds = CalendarUtil.getMonthIds();
 		String[] months = CalendarUtil.getMonths(locale);
-		boolean usePortalTimeZone = true;
 		String timeZoneID = timeZone.getID();
 		%>
 
@@ -427,9 +426,7 @@
 			</tbody>
 		</table>
 
-		<aui:input label="use-global-timezone" name="usePortalTimeZone" type="checkbox" value="<%= usePortalTimeZone %>" />
-
-		<aui:input cssClass="calendar-portlet-time-zone-field" disabled="<%= usePortalTimeZone %>" label="time-zone" name="timeZoneId" type="timeZone" value="<%= timeZoneID %>" />
+		<aui:input cssClass="calendar-portlet-time-zone-field" label="time-zone" name="timeZoneId" type="timeZone" value="<%= timeZoneID %>" />
 
 		<script>
 			(function() {
@@ -490,17 +487,4 @@
 
 	Liferay.Util.toggleRadio('<portlet:namespace />yearlyTypeDayOfWeek', ['<portlet:namespace />schedulerYearlyDayOfWeekTypeDay', '<portlet:namespace />schedulerYearlyDayOfWeekTypeMonth','<portlet:namespace />schedulerYearlyDayOfWeekTypeYear'], ['<portlet:namespace />schedulerYearlyDayOfMonthTypeDay','<portlet:namespace />schedulerYearlyDayOfMonthTypeMonth','<portlet:namespace />schedulerYearlyDayOfMonthTypeYear']);
 
-</aui:script>
-
-<aui:script use="aui-base">
-	var usePortalTimeZoneCheckbox = A.one('#<portlet:namespace />usePortalTimeZone');
-
-	if (usePortalTimeZoneCheckbox) {
-		usePortalTimeZoneCheckbox.on(
-			'change',
-			function(event) {
-				document.getElementById('<portlet:namespace />timeZoneId').disabled = usePortalTimeZoneCheckbox.attr('checked');
-			}
-		);
-	}
 </aui:script>

--- a/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/input_scheduler/page.jsp
+++ b/modules/apps/staging/staging-taglib/src/main/resources/META-INF/resources/input_scheduler/page.jsp
@@ -64,6 +64,8 @@
 
 		int[] monthIds = CalendarUtil.getMonthIds();
 		String[] months = CalendarUtil.getMonths(locale);
+		boolean usePortalTimeZone = true;
+		String timeZoneID = timeZone.getID();
 		%>
 
 		<table class="staging-publish-schedule">
@@ -425,6 +427,10 @@
 			</tbody>
 		</table>
 
+		<aui:input label="use-global-timezone" name="usePortalTimeZone" type="checkbox" value="<%= usePortalTimeZone %>" />
+
+		<aui:input cssClass="calendar-portlet-time-zone-field" disabled="<%= usePortalTimeZone %>" label="time-zone" name="timeZoneId" type="timeZone" value="<%= timeZoneID %>" />
+
 		<script>
 			(function() {
 				var tables = document.querySelectorAll('#<portlet:namespace />recurrenceTypeDailyTable, #<portlet:namespace />recurrenceTypeMonthlyTable, #<portlet:namespace />recurrenceTypeNeverTable, #<portlet:namespace />recurrenceTypeWeeklyTable, #<portlet:namespace />recurrenceTypeYearlyTable');
@@ -484,4 +490,17 @@
 
 	Liferay.Util.toggleRadio('<portlet:namespace />yearlyTypeDayOfWeek', ['<portlet:namespace />schedulerYearlyDayOfWeekTypeDay', '<portlet:namespace />schedulerYearlyDayOfWeekTypeMonth','<portlet:namespace />schedulerYearlyDayOfWeekTypeYear'], ['<portlet:namespace />schedulerYearlyDayOfMonthTypeDay','<portlet:namespace />schedulerYearlyDayOfMonthTypeMonth','<portlet:namespace />schedulerYearlyDayOfMonthTypeYear']);
 
+</aui:script>
+
+<aui:script use="aui-base">
+	var usePortalTimeZoneCheckbox = A.one('#<portlet:namespace />usePortalTimeZone');
+
+	if (usePortalTimeZoneCheckbox) {
+		usePortalTimeZoneCheckbox.on(
+			'change',
+			function(event) {
+				document.getElementById('<portlet:namespace />timeZoneId').disabled = usePortalTimeZoneCheckbox.attr('checked');
+			}
+		);
+	}
 </aui:script>

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutServiceImpl.java
@@ -51,6 +51,7 @@ import com.liferay.portal.kernel.util.Digester;
 import com.liferay.portal.kernel.util.DigesterUtil;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
+import com.liferay.portal.kernel.util.MapUtil;
 import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.TempFileEntryUtil;
 import com.liferay.portal.kernel.util.Validator;
@@ -66,6 +67,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.TimeZone;
 
 import javax.portlet.PortletPreferences;
 
@@ -800,9 +802,20 @@ public class LayoutServiceImpl extends LayoutServiceBaseImpl {
 		GroupPermissionUtil.check(
 			getPermissionChecker(), targetGroupId, ActionKeys.PUBLISH_STAGING);
 
-		Trigger trigger = TriggerFactoryUtil.createTrigger(
-			PortalUUIDUtil.generate(), groupName, schedulerStartDate,
-			schedulerEndDate, cronText);
+		Trigger trigger = null;
+
+		if (MapUtil.getBoolean(parameterMap, "usePortalTimeZone", true)) {
+			trigger = TriggerFactoryUtil.createTrigger(
+				PortalUUIDUtil.generate(), groupName, schedulerStartDate,
+				schedulerEndDate, cronText);
+		}
+		else {
+			String timeZoneId = MapUtil.getString(parameterMap, "timeZoneId");
+
+			trigger = TriggerFactoryUtil.createTrigger(
+				PortalUUIDUtil.generate(), groupName, schedulerStartDate,
+				schedulerEndDate, TimeZone.getTimeZone(timeZoneId), cronText);
+		}
 
 		User user = userPersistence.findByPrimaryKey(getUserId());
 
@@ -868,9 +881,20 @@ public class LayoutServiceImpl extends LayoutServiceBaseImpl {
 		GroupPermissionUtil.check(
 			getPermissionChecker(), sourceGroupId, ActionKeys.PUBLISH_STAGING);
 
-		Trigger trigger = TriggerFactoryUtil.createTrigger(
-			PortalUUIDUtil.generate(), groupName, schedulerStartDate,
-			schedulerEndDate, cronText);
+		Trigger trigger = null;
+
+		if (MapUtil.getBoolean(parameterMap, "usePortalTimeZone", true)) {
+			trigger = TriggerFactoryUtil.createTrigger(
+				PortalUUIDUtil.generate(), groupName, schedulerStartDate,
+				schedulerEndDate, cronText);
+		}
+		else {
+			String timeZoneId = MapUtil.getString(parameterMap, "timeZoneId");
+
+			trigger = TriggerFactoryUtil.createTrigger(
+				PortalUUIDUtil.generate(), groupName, schedulerStartDate,
+				schedulerEndDate, TimeZone.getTimeZone(timeZoneId), cronText);
+		}
 
 		User user = userPersistence.findByPrimaryKey(getUserId());
 

--- a/portal-impl/src/com/liferay/portal/service/impl/LayoutServiceImpl.java
+++ b/portal-impl/src/com/liferay/portal/service/impl/LayoutServiceImpl.java
@@ -802,20 +802,11 @@ public class LayoutServiceImpl extends LayoutServiceBaseImpl {
 		GroupPermissionUtil.check(
 			getPermissionChecker(), targetGroupId, ActionKeys.PUBLISH_STAGING);
 
-		Trigger trigger = null;
+		String timeZoneId = MapUtil.getString(parameterMap, "timeZoneId");
 
-		if (MapUtil.getBoolean(parameterMap, "usePortalTimeZone", true)) {
-			trigger = TriggerFactoryUtil.createTrigger(
-				PortalUUIDUtil.generate(), groupName, schedulerStartDate,
-				schedulerEndDate, cronText);
-		}
-		else {
-			String timeZoneId = MapUtil.getString(parameterMap, "timeZoneId");
-
-			trigger = TriggerFactoryUtil.createTrigger(
-				PortalUUIDUtil.generate(), groupName, schedulerStartDate,
-				schedulerEndDate, TimeZone.getTimeZone(timeZoneId), cronText);
-		}
+		Trigger trigger = TriggerFactoryUtil.createTrigger(
+			PortalUUIDUtil.generate(), groupName, schedulerStartDate,
+			schedulerEndDate, TimeZone.getTimeZone(timeZoneId), cronText);
 
 		User user = userPersistence.findByPrimaryKey(getUserId());
 
@@ -881,20 +872,11 @@ public class LayoutServiceImpl extends LayoutServiceBaseImpl {
 		GroupPermissionUtil.check(
 			getPermissionChecker(), sourceGroupId, ActionKeys.PUBLISH_STAGING);
 
-		Trigger trigger = null;
+		String timeZoneId = MapUtil.getString(parameterMap, "timeZoneId");
 
-		if (MapUtil.getBoolean(parameterMap, "usePortalTimeZone", true)) {
-			trigger = TriggerFactoryUtil.createTrigger(
-				PortalUUIDUtil.generate(), groupName, schedulerStartDate,
-				schedulerEndDate, cronText);
-		}
-		else {
-			String timeZoneId = MapUtil.getString(parameterMap, "timeZoneId");
-
-			trigger = TriggerFactoryUtil.createTrigger(
-				PortalUUIDUtil.generate(), groupName, schedulerStartDate,
-				schedulerEndDate, TimeZone.getTimeZone(timeZoneId), cronText);
-		}
+		Trigger trigger = TriggerFactoryUtil.createTrigger(
+			PortalUUIDUtil.generate(), groupName, schedulerStartDate,
+			schedulerEndDate, TimeZone.getTimeZone(timeZoneId), cronText);
 
 		User user = userPersistence.findByPrimaryKey(getUserId());
 

--- a/portal-kernel/src/com/liferay/exportimport/kernel/lar/ExportImportDateUtil.java
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/lar/ExportImportDateUtil.java
@@ -105,11 +105,22 @@ public class ExportImportDateUtil {
 			portletRequest, paramPrefix + "Minute");
 		int dateAmPm = ParamUtil.getInteger(
 			portletRequest, paramPrefix + "AmPm");
+		boolean usePortalTimeZone = ParamUtil.getBoolean(
+			portletRequest, "usePortalTimeZone");
+
+		TimeZone timeZone = null;
+
+		if (usePortalTimeZone) {
+			timeZone = themeDisplay.getTimeZone();
+		}
+		else {
+			timeZone = TimeZoneUtil.getTimeZone(
+				ParamUtil.getString(portletRequest, "timeZoneId"));
+		}
 
 		return getCalendar(
 			dateAmPm, dateYear, dateMonth, dateDay, dateHour, dateMinute,
-			themeDisplay.getLocale(), themeDisplay.getTimeZone(),
-			timeZoneSensitive);
+			themeDisplay.getLocale(), timeZone, timeZoneSensitive);
 	}
 
 	public static DateRange getDateRange(

--- a/portal-kernel/src/com/liferay/exportimport/kernel/lar/ExportImportDateUtil.java
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/lar/ExportImportDateUtil.java
@@ -105,18 +105,9 @@ public class ExportImportDateUtil {
 			portletRequest, paramPrefix + "Minute");
 		int dateAmPm = ParamUtil.getInteger(
 			portletRequest, paramPrefix + "AmPm");
-		boolean usePortalTimeZone = ParamUtil.getBoolean(
-			portletRequest, "usePortalTimeZone");
 
-		TimeZone timeZone = null;
-
-		if (usePortalTimeZone) {
-			timeZone = themeDisplay.getTimeZone();
-		}
-		else {
-			timeZone = TimeZoneUtil.getTimeZone(
-				ParamUtil.getString(portletRequest, "timeZoneId"));
-		}
+		TimeZone timeZone = TimeZoneUtil.getTimeZone(
+			ParamUtil.getString(portletRequest, "timeZoneId"));
 
 		return getCalendar(
 			dateAmPm, dateYear, dateMonth, dateDay, dateHour, dateMinute,

--- a/portal-kernel/src/com/liferay/portal/kernel/scheduler/TriggerFactory.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/scheduler/TriggerFactory.java
@@ -17,6 +17,7 @@ package com.liferay.portal.kernel.scheduler;
 import aQute.bnd.annotation.ProviderType;
 
 import java.util.Date;
+import java.util.TimeZone;
 
 /**
  * @author Tina Tian
@@ -31,6 +32,10 @@ public interface TriggerFactory {
 	public Trigger createTrigger(
 		String jobName, String groupName, Date startDate, Date endDate,
 		String cronExpression);
+
+	public Trigger createTrigger(
+		String jobName, String groupName, Date startDate, Date endDate,
+		TimeZone timeZone, String cronExpression);
 
 	public Trigger createTrigger(Trigger trigger, Date startDate, Date endDate);
 

--- a/portal-kernel/src/com/liferay/portal/kernel/scheduler/TriggerFactoryUtil.java
+++ b/portal-kernel/src/com/liferay/portal/kernel/scheduler/TriggerFactoryUtil.java
@@ -17,6 +17,7 @@ package com.liferay.portal.kernel.scheduler;
 import com.liferay.portal.kernel.util.ServiceProxyFactory;
 
 import java.util.Date;
+import java.util.TimeZone;
 
 /**
  * @author Shuyang Zhou
@@ -37,6 +38,14 @@ public class TriggerFactoryUtil {
 
 		return _triggerFactory.createTrigger(
 			jobName, groupName, startDate, endDate, cronExpression);
+	}
+
+	public static Trigger createTrigger(
+		String jobName, String groupName, Date startDate, Date endDate,
+		TimeZone timeZone, String cronExpression) {
+
+		return _triggerFactory.createTrigger(
+			jobName, groupName, startDate, endDate, timeZone, cronExpression);
 	}
 
 	public static Trigger createTrigger(


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-93315

Hi @moltam89,

I found the following looking into the issues you mentioned in https://github.com/moltam89/liferay-portal/pull/492#issuecomment-485893441:
- The `timeZoneId` was missing from the parameterMap for publishes based on templates because parameters were mostly being copied from the template instead. Added commit for this: https://github.com/moltam89/liferay-portal/commit/fa5eb15178c806f958537b6061fcb780f122718f
- As for the issues with remote publishing, this was because I forgot to update both the live and remote versions of the method in `LayoutServiceImpl`. To simplify the commit history I just amended https://github.com/moltam89/liferay-portal/commit/7fd4cebf6c18dee4bb9b9a8848f158969fe638ed and https://github.com/moltam89/liferay-portal/commit/cca3722db671d619922d6d5403fb8e2d4a41fa8e so they now affect both

Let me know if there are any more concerns when you get the chance. Thanks again for taking a look at this.

Copied from the previous pull:
> This change is to allow scheduled publishes to use times that can be scheduled in different time zones, rather than always defaulting to the user's time zone.
> 
> We are being pushed to "fix" this on our end, as currently there is no way for Liferay to handle staging publishes across different time zones (that may need to have their times managed separately -- for example, if some would follow daylight savings time and some wouldn't).
> 
> To accomplish this, I copied the time zone selector UI element used by the Calendar portlet and added new API that sets the time zone for the schedules created for Quartz. Quartz itself (as I've seen in my own testing) already compensates for time changes and such, so all the changes here need to do is propagate the time zone information where needed to achieve the goal of scheduling for different time zones.