### PR TITLE
LPS-97162

### DIFF
--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalArticleStagedModelDataHandler.java
@@ -526,6 +526,12 @@ public class JournalArticleStagedModelDataHandler
 				JournalArticle.class + ".groupId");
 
 		articleGroupIds.put(articleArticleId, existingArticle.getGroupId());
+
+		Map<Long, Long> articlePrimaryKeys =
+			(Map<Long, Long>)portletDataContext.getNewPrimaryKeysMap(
+				JournalArticle.class + ".primaryKey");
+
+		articlePrimaryKeys.put(articleId, existingArticle.getPrimaryKey());
 	}
 
 	@Override


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-97162

From @wanderlast:

> This fix is relatively straightforward and originates from [PTR-1004](https://issues.liferay.com/browse/PTR-1004). It resolves an issue where global content can cause a NoSuchArticleException due to staging not previously adding the articlePrimaryKey when a reference is validated. Please let me know if you have any questions about this issue or if you need me to pass this along to someone else. Thanks! 