### PR TITLE
[TECHNICAL-SUPPORT] LPS-97825

### DIFF
--- a/modules/apps/staging/staging-configuration-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/staging/staging-configuration-web/src/main/resources/META-INF/resources/view.jsp
@@ -71,6 +71,7 @@ BackgroundTask lastCompletedInitialPublicationBackgroundTask = BackgroundTaskMan
 				<aui:input name="groupId" type="hidden" value="<%= liveGroupId %>" />
 				<aui:input name="liveGroupId" type="hidden" value="<%= liveGroupId %>" />
 				<aui:input name="stagingGroupId" type="hidden" value="<%= stagingGroupId %>" />
+				<aui:input name="forceDisable" type="hidden" value="<%= false %>" />
 
 				<c:if test="<%= !privateLayoutSet.isLayoutSetPrototypeLinkActive() && !publicLayoutSet.isLayoutSetPrototypeLinkActive() %>">
 					<div class="sheet-header">
@@ -157,7 +158,7 @@ BackgroundTask lastCompletedInitialPublicationBackgroundTask = BackgroundTaskMan
 </c:choose>
 
 <script>
-	function <portlet:namespace />saveGroup() {
+	function <portlet:namespace />saveGroup(forceDisable) {
 		var form = document.<portlet:namespace />fm;
 		var ok = true;
 
@@ -196,6 +197,13 @@ BackgroundTask lastCompletedInitialPublicationBackgroundTask = BackgroundTaskMan
 				}
 			}
 		</c:if>
+
+		if (forceDisable) {
+			form.elements['<portlet:namespace />forceDisable'].value = true;
+			form.elements['<portlet:namespace />none'].checked = true;
+			form.elements['<portlet:namespace />redirect'].value = '<portlet:renderURL><portlet:param name="mvcPath" value="/view.jsp" /><portlet:param name="historyKey" value='<%= renderResponse.getNamespace() + "staging" %>' /></portlet:renderURL>';
+			form.elements['<portlet:namespace />remote'].checked = false;
+		}
 
 		if (ok) {
 			submitForm(form);


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-97825

Hello Tamás,

Can you take a look at the fix for remote staging for us? It seems that the option to forcibly disable is not working because the function calls (you can see an example in [error_remote_export_exception.jspf](https://github.com/liferay/liferay-portal/blob/master/modules/apps/staging/staging-configuration-web/src/main/resources/META-INF/resources/error_remote_export_exception.jspf#L29)) to a script are passing in an unused parameter.

Please let us know if there are any concerns with this change. Thank you!

Notes from @knchau:

> The issue is that when remote staging is inaccessible, the staging server cannot be disabled. This is because the link never set the value to true. So the service context fetched a false value for 'forceDisable' since it was never explicitly set.
> 
> I changed the function to take in a parameter and used that parameter to set the value of 'forceDisable' to true. This allows the staging site to forcibly disable from the remote staging site.