### PR TITLE
[TECHNICAL-SUPPORT] LPS-98317

### DIFF
--- a/modules/apps/journal/journal-service/build.gradle
+++ b/modules/apps/journal/journal-service/build.gradle
@@ -24,6 +24,7 @@ dependencies {
 	compileOnly project(":apps:changeset:changeset-api")
 	compileOnly project(":apps:comment:comment-api")
 	compileOnly project(":apps:document-library:document-library-api")
+	compileOnly project(":apps:dynamic-data-lists:dynamic-data-lists-api")
 	compileOnly project(":apps:dynamic-data-mapping:dynamic-data-mapping-api")
 	compileOnly project(":apps:export-import:export-import-api")
 	compileOnly project(":apps:friendly-url:friendly-url-api")

--- a/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalPortletDataHandler.java
+++ b/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalPortletDataHandler.java
@@ -17,6 +17,7 @@ package com.liferay.journal.internal.exportimport.data.handler;
 import com.liferay.changeset.model.ChangesetCollection;
 import com.liferay.changeset.service.ChangesetCollectionLocalService;
 import com.liferay.changeset.service.ChangesetEntryLocalService;
+import com.liferay.dynamic.data.lists.model.DDLRecordSet;
 import com.liferay.dynamic.data.mapping.model.DDMStructure;
 import com.liferay.dynamic.data.mapping.model.DDMTemplate;
 import com.liferay.dynamic.data.mapping.service.DDMStructureLocalService;
@@ -590,8 +591,13 @@ public class JournalPortletDataHandler extends BasePortletDataHandler {
 				long articleClassNameId = _portal.getClassNameId(
 					JournalArticle.class);
 
+				long ddlRecordSetClassNameId = _portal.getClassNameId(
+					DDLRecordSet.class);
+
 				ddmStructureDynamicQuery.add(
-					classNameIdProperty.eq(articleClassNameId));
+					RestrictionsFactoryUtil.or(
+						classNameIdProperty.eq(articleClassNameId),
+						classNameIdProperty.eq(ddlRecordSetClassNameId)));
 
 				ddmStructureDynamicQuery.setProjection(
 					ProjectionFactoryUtil.property("structureId"));


### PR DESCRIPTION
https://issues.liferay.com/browse/LPS-98317
https://issues.liferay.com/browse/LPP-34462

Hello Tamás,

Can you take a look at this fix for exporting DDMTemplates for us? The fix in mind resolves two slightly different issues between master and 7.0.x (see the differing steps on the LPS) but we thought it would make sense to push the same fix for master to keep it always exported when appropriate. Please let us know what you think though. Thank you.

Notes from @joshuacords:

> I originally thought that the LPP was resolved by [LPS-82446](https://issues.liferay.com/browse/LPS-82446), however digging deeper revealed that [LPS-82446](https://issues.liferay.com/browse/LPS-82446) is dependent on the changes of technical tasks [LPS-81438](https://issues.liferay.com/browse/LPS-81438) and [LPS-80370](https://issues.liferay.com/browse/LPS-80370), specifically the change from [this](https://github.com/liferay/liferay-portal-ee/blob/f55aeeaaee96e12c848176e8cf00221c4dc336b9/modules/apps/web-experience/journal/journal-service/src/main/java/com/liferay/journal/exportimport/data/handler/JournalPortletDataHandler.java#L373-L404) to using [populateLastPublishDateCounts](https://github.com/liferay/liferay-portal-ee/blob/614c1cbe9f3fdbea927648deedd17825d5f75887/modules/apps/journal/journal-service/src/main/java/com/liferay/journal/internal/exportimport/data/handler/JournalPortletDataHandler.java#L402-L421). I also found that [LPS-82446](https://issues.liferay.com/browse/LPS-82446) wasn't reproducible in 7.0.x. So while the totality of these code changes prevent the issue in 7.1.x and up, these are not changes that can be brought back.
> 
> My approach was to updated the dynamicQuery criteria which was not including DDLRecordSets when it was searching classNameIds. I believe this simple change should be enough to detect the modification of DDLTemplates.

> I believe Web Content > Templates should be visible regardless of whether All, From Last Publish Date, or any other filter as long as a DDMTemplate was created during that filter. If DDL is chosen and Web Content is not chosen, referenced DDMTemplates will still be exported.
> 
> My approach was to updated the dynamicQuery criteria which was not including DDLRecordSets when it was searching classNameIds. I believe this simple change should be enough to detect the modification of DDLTemplates.
> 
> PS: I found the differences between the Export files was just that the one with my changes was showing that Web Content was included and was referencing the DDMTemplate; it was not double exporting it.