### PR TITLE
[TECHNICAL-SUPPORT] LPS-104944 Import page template with "Copy as new" creates duplicate UUIDs for Layout

### DIFF
--- a/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-admin-web/src/main/java/com/liferay/layout/admin/web/internal/exportimport/data/handler/LayoutStagedModelDataHandler.java
@@ -105,6 +105,7 @@ import com.liferay.portal.kernel.util.PortletKeys;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.kernel.util.Validator;
+import com.liferay.portal.kernel.uuid.PortalUUIDUtil;
 import com.liferay.portal.kernel.xml.Document;
 import com.liferay.portal.kernel.xml.Element;
 import com.liferay.portal.kernel.xml.SAXReaderUtil;
@@ -468,6 +469,7 @@ public class LayoutStagedModelDataHandler
 		Layout existingLayout = null;
 
 		String friendlyURL = layout.getFriendlyURL();
+		String uuid = layout.getUuid();
 
 		String layoutsImportMode = MapUtil.getString(
 			portletDataContext.getParameterMap(),
@@ -481,6 +483,15 @@ public class LayoutStagedModelDataHandler
 				groupId, privateLayout);
 
 			friendlyURL = StringPool.SLASH + layoutId;
+		}
+		else if (layoutsImportMode.equals(
+					PortletDataHandlerKeys.
+						LAYOUTS_IMPORT_MODE_ADD_AS_NEW_PROTOTYPE)) {
+
+			layoutId = _layoutLocalService.getNextLayoutId(
+				groupId, privateLayout);
+
+			uuid = PortalUUIDUtil.generate();
 		}
 		else if (layoutsImportMode.equals(
 					PortletDataHandlerKeys.
@@ -513,7 +524,7 @@ public class LayoutStagedModelDataHandler
 						LAYOUTS_IMPORT_MODE_CREATED_FROM_PROTOTYPE)) {
 
 			existingLayout = _layoutLocalService.fetchLayoutByUuidAndGroupId(
-				layout.getUuid(), groupId, privateLayout);
+				uuid, groupId, privateLayout);
 
 			if (SitesUtil.isLayoutModifiedSinceLastMerge(existingLayout)) {
 				layouts.put(oldLayoutId, existingLayout);
@@ -556,7 +567,7 @@ public class LayoutStagedModelDataHandler
 			// PortletDataHandlerKeys.LAYOUTS_IMPORT_MODE_MERGE_BY_LAYOUT_UUID
 
 			existingLayout = _layoutLocalService.fetchLayoutByUuidAndGroupId(
-				layout.getUuid(), groupId, privateLayout);
+				uuid, groupId, privateLayout);
 
 			if (existingLayout == null) {
 				existingLayout = _layoutLocalService.fetchLayoutByFriendlyURL(
@@ -602,7 +613,7 @@ public class LayoutStagedModelDataHandler
 					PortletDataHandlerKeys.
 						LAYOUTS_IMPORT_MODE_CREATED_FROM_PROTOTYPE)) {
 
-				importedLayout.setSourcePrototypeLayoutUuid(layout.getUuid());
+				importedLayout.setSourcePrototypeLayoutUuid(uuid);
 
 				layoutId = _layoutLocalService.getNextLayoutId(
 					groupId, privateLayout);
@@ -618,7 +629,7 @@ public class LayoutStagedModelDataHandler
 					layout.getSourcePrototypeLayoutUuid());
 			}
 
-			importedLayout.setUuid(layout.getUuid());
+			importedLayout.setUuid(uuid);
 			importedLayout.setGroupId(groupId);
 			importedLayout.setUserId(userId);
 			importedLayout.setPrivateLayout(privateLayout);

--- a/modules/apps/layout/layout-prototype-impl/src/main/java/com/liferay/layout/prototype/internal/exportimport/data/handler/LayoutPrototypeStagedModelDataHandler.java
+++ b/modules/apps/layout/layout-prototype-impl/src/main/java/com/liferay/layout/prototype/internal/exportimport/data/handler/LayoutPrototypeStagedModelDataHandler.java
@@ -17,6 +17,7 @@ package com.liferay.layout.prototype.internal.exportimport.data.handler;
 import com.liferay.exportimport.data.handler.base.BaseStagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.ExportImportPathUtil;
 import com.liferay.exportimport.kernel.lar.PortletDataContext;
+import com.liferay.exportimport.kernel.lar.PortletDataHandlerKeys;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandler;
 import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -32,9 +33,12 @@ import com.liferay.portal.kernel.service.UserLocalService;
 import com.liferay.portal.kernel.util.GetterUtil;
 import com.liferay.portal.kernel.util.ListUtil;
 import com.liferay.portal.kernel.util.LocaleUtil;
+import com.liferay.portal.kernel.util.MapUtil;
+import com.liferay.portal.kernel.util.Validator;
 import com.liferay.portal.kernel.xml.Element;
 
 import java.util.List;
+import java.util.Map;
 
 import org.osgi.service.component.annotations.Component;
 import org.osgi.service.component.annotations.Reference;
@@ -239,10 +243,25 @@ public class LayoutPrototypeStagedModelDataHandler
 		boolean privateLayout = portletDataContext.isPrivateLayout();
 		long scopeGroupId = portletDataContext.getScopeGroupId();
 
+		Map<String, String[]> parameterMap =
+			portletDataContext.getParameterMap();
+
+		String layoutsImportMode = MapUtil.getString(
+			parameterMap, PortletDataHandlerKeys.LAYOUTS_IMPORT_MODE);
+
 		try {
 			portletDataContext.setGroupId(importedGroupId);
 			portletDataContext.setPrivateLayout(true);
 			portletDataContext.setScopeGroupId(importedGroupId);
+
+			if (!portletDataContext.isDataStrategyMirror()) {
+				parameterMap.put(
+					PortletDataHandlerKeys.LAYOUTS_IMPORT_MODE,
+					new String[] {
+						PortletDataHandlerKeys.
+							LAYOUTS_IMPORT_MODE_ADD_AS_NEW_PROTOTYPE
+					});
+			}
 
 			StagedModelDataHandlerUtil.importReferenceStagedModels(
 				portletDataContext, layoutPrototype, Layout.class);
@@ -251,6 +270,20 @@ public class LayoutPrototypeStagedModelDataHandler
 			portletDataContext.setGroupId(groupId);
 			portletDataContext.setPrivateLayout(privateLayout);
 			portletDataContext.setScopeGroupId(scopeGroupId);
+
+			if (Validator.isNull(layoutsImportMode)) {
+				if (parameterMap.containsKey(
+						PortletDataHandlerKeys.LAYOUTS_IMPORT_MODE)) {
+
+					parameterMap.remove(
+						PortletDataHandlerKeys.LAYOUTS_IMPORT_MODE);
+				}
+			}
+			else {
+				parameterMap.put(
+					PortletDataHandlerKeys.LAYOUTS_IMPORT_MODE,
+					new String[] {layoutsImportMode});
+			}
 		}
 	}
 

--- a/modules/apps/layout/layout-prototype-test/src/testIntegration/java/com/liferay/layout/prototype/internal/exportimport/data/handler/test/LayoutPrototypeStagedModelDataHandlerTest.java
+++ b/modules/apps/layout/layout-prototype-test/src/testIntegration/java/com/liferay/layout/prototype/internal/exportimport/data/handler/test/LayoutPrototypeStagedModelDataHandlerTest.java
@@ -16,6 +16,8 @@ package com.liferay.layout.prototype.internal.exportimport.data.handler.test;
 
 import com.liferay.arquillian.extension.junit.bridge.junit.Arquillian;
 import com.liferay.exportimport.kernel.lar.ExportImportThreadLocal;
+import com.liferay.exportimport.kernel.lar.PortletDataHandlerKeys;
+import com.liferay.exportimport.kernel.lar.StagedModelDataHandlerUtil;
 import com.liferay.exportimport.test.util.lar.BaseStagedModelDataHandlerTestCase;
 import com.liferay.layout.test.util.LayoutTestUtil;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -29,6 +31,7 @@ import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.LayoutPrototypeLocalServiceUtil;
 import com.liferay.portal.kernel.test.rule.AggregateTestRule;
 import com.liferay.portal.kernel.test.util.RandomTestUtil;
+import com.liferay.portal.kernel.util.LocaleUtil;
 import com.liferay.portal.kernel.util.StringUtil;
 import com.liferay.portal.kernel.util.UnicodeProperties;
 import com.liferay.portal.test.rule.LiferayIntegrationTestRule;
@@ -41,6 +44,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 
 /**
@@ -80,6 +84,60 @@ public class LayoutPrototypeStagedModelDataHandlerTest
 		}
 
 		ExportImportThreadLocal.setLayoutStagingInProcess(false);
+	}
+
+	@Test
+	public void testImportCopyAsNew() throws Exception {
+		initExport();
+
+		Map<String, List<StagedModel>> dependentStagedModelsMap =
+			addDependentStagedModelsMap(stagingGroup);
+
+		StagedModel stagedModel = addStagedModel(
+			stagingGroup, dependentStagedModelsMap);
+
+		StagedModelDataHandlerUtil.exportStagedModel(
+			portletDataContext, stagedModel);
+
+		validateExport(
+			portletDataContext, stagedModel, dependentStagedModelsMap);
+
+		String layoutPrototypeName = _layoutPrototype.getNameCurrentValue();
+
+		_layoutPrototype.setName(
+			RandomTestUtil.randomString(),
+			LocaleUtil.fromLanguageId(
+				_layoutPrototype.getNameCurrentLanguageId()));
+
+		LayoutPrototypeLocalServiceUtil.updateLayoutPrototype(_layoutPrototype);
+
+		initImport();
+
+		StagedModel exportedStagedModel = readExportedStagedModel(stagedModel);
+
+		Assert.assertNotNull(exportedStagedModel);
+
+		portletDataContext.setDataStrategy(
+			PortletDataHandlerKeys.DATA_STRATEGY_COPY_AS_NEW);
+
+		StagedModelDataHandlerUtil.importStagedModel(
+			portletDataContext, exportedStagedModel);
+
+		LayoutPrototype importedLayoutPrototype =
+			LayoutPrototypeLocalServiceUtil.getLayoutPrototype(
+				_layoutPrototype.getCompanyId(), layoutPrototypeName);
+
+		Assert.assertNotEquals(
+			_layoutPrototype.getUuid(), importedLayoutPrototype.getUuid());
+
+		Layout layout = _layoutPrototype.getLayout();
+
+		Layout importedLayout = importedLayoutPrototype.getLayout();
+
+		Assert.assertNotEquals(layout.getUuid(), importedLayout.getUuid());
+
+		LayoutPrototypeLocalServiceUtil.deleteLayoutPrototype(
+			importedLayoutPrototype);
 	}
 
 	@Override

--- a/portal-kernel/src/com/liferay/exportimport/kernel/lar/PortletDataHandlerKeys.java
+++ b/portal-kernel/src/com/liferay/exportimport/kernel/lar/PortletDataHandlerKeys.java
@@ -55,6 +55,9 @@ public class PortletDataHandlerKeys {
 
 	public static final String LAYOUTS_IMPORT_MODE_ADD_AS_NEW = "ADD_AS_NEW";
 
+	public static final String LAYOUTS_IMPORT_MODE_ADD_AS_NEW_PROTOTYPE =
+			"ADD_AS_NEW_PROTOTYPE";
+	
 	public static final String LAYOUTS_IMPORT_MODE_CREATED_FROM_PROTOTYPE =
 		"CREATED_FROM_PROTOTYPE";
 


### PR DESCRIPTION
Hi @moltam89 ,

I added new LAYOUT_IMPORT_MODE, since this is a special case. I noticed, when importing just simple Layouts with "Copy as new", they don't actually create a new copy. I assumed that this is intentional, and I did not want to change this behavior.
However, when we import Layouts as part of LayoutPrototypes with "Copy as new", they require separate instances. This was working almost perfectly, since LayoutStagedModelDataHandler.doImportStagedModel(..) fell back to its default mode: 
https://github.com/moltam89/liferay-portal/commit/12635da792258158780ce2f4eb743e12255f740d#diff-d517d25fa1a6cdd8a405f33d96b3c6d4L553-L557 .
The only problem was that it used the same UUID for the new Layout.

Please review my changes.

Thanks,
Vendel