### PR TITLE
Lps 94690 2

### DIFF
--- a/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/_extras.scss
+++ b/modules/apps/frontend-theme/frontend-theme-styled/src/main/resources/META-INF/resources/_styled/css/_extras.scss
@@ -52,8 +52,10 @@
 }
 
 .product-menu {
-	.loading-animation {
-		margin-top: 160px;
+	:not(.inline-item) {
+		> .loading-animation {
+			margin-top: 160px;
+		}
 	}
 }
 

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/display/context/SiteAdministrationPanelCategoryDisplayContext.java
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/display/context/SiteAdministrationPanelCategoryDisplayContext.java
@@ -19,6 +19,7 @@ import com.liferay.application.list.PanelCategory;
 import com.liferay.application.list.constants.ApplicationListWebKeys;
 import com.liferay.application.list.constants.PanelCategoryKeys;
 import com.liferay.application.list.display.context.logic.PanelCategoryHelper;
+import com.liferay.exportimport.kernel.exception.RemoteExportException;
 import com.liferay.exportimport.kernel.staging.StagingUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -36,6 +37,7 @@ import com.liferay.portal.kernel.security.permission.ActionKeys;
 import com.liferay.portal.kernel.service.LayoutLocalServiceUtil;
 import com.liferay.portal.kernel.service.UserLocalServiceUtil;
 import com.liferay.portal.kernel.service.permission.GroupPermissionUtil;
+import com.liferay.portal.kernel.servlet.SessionErrors;
 import com.liferay.portal.kernel.theme.ThemeDisplay;
 import com.liferay.portal.kernel.util.PortalUtil;
 import com.liferay.portal.kernel.util.ResourceBundleUtil;
@@ -187,6 +189,8 @@ public class SiteAdministrationPanelCategoryDisplayContext {
 				_log.error("Unable to get live group URL: " + pe.getMessage());
 			}
 			catch (SystemException se) {
+				SessionErrors.add(_portletRequest, RemoteExportException.class);
+
 				Throwable cause = se.getCause();
 
 				if (!(cause instanceof ConnectException)) {

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/display/context/SiteAdministrationPanelCategoryDisplayContext.java
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/java/com/liferay/product/navigation/site/administration/internal/display/context/SiteAdministrationPanelCategoryDisplayContext.java
@@ -19,7 +19,6 @@ import com.liferay.application.list.PanelCategory;
 import com.liferay.application.list.constants.ApplicationListWebKeys;
 import com.liferay.application.list.constants.PanelCategoryKeys;
 import com.liferay.application.list.display.context.logic.PanelCategoryHelper;
-import com.liferay.exportimport.kernel.exception.RemoteExportException;
 import com.liferay.exportimport.kernel.staging.StagingUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.exception.PortalException;
@@ -164,7 +163,7 @@ public class SiteAdministrationPanelCategoryDisplayContext {
 		return "live";
 	}
 
-	public String getLiveGroupURL() throws RemoteExportException {
+	public String getLiveGroupURL() {
 		if (_liveGroupURL != null) {
 			return _liveGroupURL;
 		}
@@ -199,9 +198,6 @@ public class SiteAdministrationPanelCategoryDisplayContext {
 						"Unable to connect to remote live: " +
 							cause.getMessage());
 				}
-
-				throw new RemoteExportException(
-					RemoteExportException.BAD_CONNECTION);
 			}
 		}
 		else if (group.isStagingGroup()) {

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/init.jsp
@@ -41,6 +41,7 @@ page import="com.liferay.portal.kernel.portlet.LiferayWindowState" %><%@
 page import="com.liferay.portal.kernel.portlet.PortletURLFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.portlet.RequestBackedPortletURLFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.service.LayoutLocalServiceUtil" %><%@
+page import="com.liferay.portal.kernel.servlet.SessionErrors" %><%@
 page import="com.liferay.portal.kernel.util.HtmlUtil" %><%@
 page import="com.liferay.portal.kernel.util.Validator" %><%@
 page import="com.liferay.product.navigation.product.menu.constants.ProductNavigationProductMenuPortletKeys" %><%@

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/init.jsp
@@ -29,15 +29,11 @@ taglib uri="http://liferay.com/tld/ui" prefix="liferay-ui" %>
 page import="com.liferay.application.list.PanelAppRegistry" %><%@
 page import="com.liferay.application.list.PanelCategory" %><%@
 page import="com.liferay.application.list.constants.ApplicationListWebKeys" %><%@
-page import="com.liferay.exportimport.kernel.exception.RemoteExportException" %><%@
 page import="com.liferay.item.selector.ItemSelector" %><%@
 page import="com.liferay.item.selector.ItemSelectorCriterion" %><%@
 page import="com.liferay.item.selector.criteria.URLItemSelectorReturnType" %><%@
 page import="com.liferay.item.selector.criteria.group.criterion.GroupItemSelectorCriterion" %><%@
 page import="com.liferay.petra.string.StringPool" %><%@
-page import="com.liferay.portal.kernel.exception.SystemException" %><%@
-page import="com.liferay.portal.kernel.log.Log" %><%@
-page import="com.liferay.portal.kernel.log.LogFactoryUtil" %><%@
 page import="com.liferay.portal.kernel.model.Group" %><%@
 page import="com.liferay.portal.kernel.model.GroupConstants" %><%@
 page import="com.liferay.portal.kernel.model.Layout" %><%@

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_body.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_body.jsp
@@ -82,7 +82,7 @@ boolean showStagingInfo = siteAdministrationPanelCategoryDisplayContext.isShowSt
 				}).render();
 			};
 
-			AUI().ready(function() {
+			Liferay.on('allPortletsReady', function() {
 				A.io.request(
 					'<%= liveGroupURL = siteAdministrationPanelCategoryDisplayContext.getLiveGroupURL() %>',
 					{

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_body.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_body.jsp
@@ -92,10 +92,10 @@ boolean showStagingInfo = siteAdministrationPanelCategoryDisplayContext.isShowSt
 							},
 							failure: failureCallback,
 							success: function() {
-								if (<%= !liveGroupURL.equals(StringPool.BLANK) %>) {
+								if (<%= SessionErrors.isEmpty(liferayPortletRequest) %>) {
 									link.attr('href', '<%= liveGroupURL %>');
 
-									if (link.getAttribute('href') === 'javascript:;') {
+									if (link.getAttribute('href') === '') {
 										link.removeAttribute('href');
 										link.addClass('active');
 									}

--- a/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_body.jsp
+++ b/modules/apps/product-navigation/product-navigation-site-administration/src/main/resources/META-INF/resources/sites/site_administration_body.jsp
@@ -69,7 +69,7 @@ boolean showStagingInfo = siteAdministrationPanelCategoryDisplayContext.isShowSt
 			var loader = A.one('#<portlet:namespace />loader');
 
 			var failureCallback = function() {
-				loader.hide();
+				link.removeAttribute('href');
 
 				new A.Tooltip({
 					bodyContent: Liferay.Language.get(
@@ -92,13 +92,19 @@ boolean showStagingInfo = siteAdministrationPanelCategoryDisplayContext.isShowSt
 							},
 							failure: failureCallback,
 							success: function() {
-								loader.hide();
+								if (<%= !liveGroupURL.equals(StringPool.BLANK) %>) {
+									link.attr('href', '<%= liveGroupURL %>');
 
-								link.attr('href', '<%= liveGroupURL %>');
-
-								if (link.getAttribute('href') === 'javascript:;') {
-									link.addClass('active');
+									if (link.getAttribute('href') === 'javascript:;') {
+										link.removeAttribute('href');
+										link.addClass('active');
+									}
+								} else {
+									failureCallback();
 								}
+							},
+							complete: function() {
+								loader.hide();
 							}
 						}
 					}

--- a/modules/apps/staging/staging-bar-web/src/main/java/com/liferay/staging/bar/web/internal/display/context/StagingBarPortletDisplayContext.java
+++ b/modules/apps/staging/staging-bar-web/src/main/java/com/liferay/staging/bar/web/internal/display/context/StagingBarPortletDisplayContext.java
@@ -1,0 +1,84 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+package com.liferay.staging.bar.web.internal.display.context;
+
+import com.liferay.exportimport.kernel.exception.RemoteExportException;
+import com.liferay.exportimport.kernel.staging.StagingUtil;
+import com.liferay.petra.string.StringPool;
+import com.liferay.portal.kernel.exception.SystemException;
+import com.liferay.portal.kernel.log.Log;
+import com.liferay.portal.kernel.log.LogFactoryUtil;
+import com.liferay.portal.kernel.model.Group;
+import com.liferay.portal.kernel.model.Layout;
+import com.liferay.portal.kernel.security.auth.AuthException;
+import com.liferay.portal.kernel.servlet.SessionErrors;
+
+import java.net.ConnectException;
+
+import javax.portlet.RenderRequest;
+
+/**
+ * @author Kimberly Chau
+ */
+public class StagingBarPortletDisplayContext {
+
+	public StagingBarPortletDisplayContext(RenderRequest renderRequest) {
+		_renderRequest = renderRequest;
+	}
+
+	public String getLiveGroupURL(Group group, Group liveGroup, Layout layout) {
+		String remoteSiteURL = StringPool.BLANK;
+
+		if ((liveGroup != null) && group.isStagedRemotely()) {
+			try {
+				remoteSiteURL = StagingUtil.getRemoteSiteURL(
+					group, layout.isPrivateLayout());
+			}
+			catch (AuthException ae) {
+				_log.error(ae.getMessage());
+
+				SessionErrors.add(_renderRequest, AuthException.class);
+			}
+			catch (SystemException se) {
+				Throwable cause = se.getCause();
+
+				if (!(cause instanceof ConnectException)) {
+					throw se;
+				}
+
+				if (_log.isWarnEnabled()) {
+					_log.warn(
+						"Unable to connect to remote live: " +
+							cause.getMessage());
+				}
+
+				SessionErrors.add(_renderRequest, RemoteExportException.class);
+			}
+			catch (Exception e) {
+				_log.error(e, e);
+
+				SessionErrors.add(_renderRequest, Exception.class);
+			}
+		}
+
+		return remoteSiteURL;
+	}
+
+	private static final Log _log = LogFactoryUtil.getLog(
+		StagingBarPortletDisplayContext.class);
+
+	private final RenderRequest _renderRequest;
+
+}

--- a/modules/apps/staging/staging-bar-web/src/main/java/com/liferay/staging/bar/web/internal/portlet/StagingBarPortlet.java
+++ b/modules/apps/staging/staging-bar-web/src/main/java/com/liferay/staging/bar/web/internal/portlet/StagingBarPortlet.java
@@ -14,11 +14,9 @@
 
 package com.liferay.staging.bar.web.internal.portlet;
 
-import com.liferay.exportimport.kernel.exception.RemoteExportException;
 import com.liferay.exportimport.kernel.staging.LayoutStagingUtil;
 import com.liferay.exportimport.kernel.staging.Staging;
 import com.liferay.exportimport.kernel.staging.StagingURLHelper;
-import com.liferay.exportimport.kernel.staging.StagingUtil;
 import com.liferay.petra.string.StringPool;
 import com.liferay.portal.kernel.bean.BeanPropertiesUtil;
 import com.liferay.portal.kernel.dao.orm.DynamicQuery;
@@ -28,8 +26,6 @@ import com.liferay.portal.kernel.exception.LayoutSetBranchNameException;
 import com.liferay.portal.kernel.exception.NoSuchGroupException;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
-import com.liferay.portal.kernel.log.Log;
-import com.liferay.portal.kernel.log.LogFactoryUtil;
 import com.liferay.portal.kernel.model.Group;
 import com.liferay.portal.kernel.model.Layout;
 import com.liferay.portal.kernel.model.LayoutBranch;
@@ -37,7 +33,6 @@ import com.liferay.portal.kernel.model.LayoutRevision;
 import com.liferay.portal.kernel.model.LayoutSetBranch;
 import com.liferay.portal.kernel.model.Release;
 import com.liferay.portal.kernel.portlet.bridges.mvc.MVCPortlet;
-import com.liferay.portal.kernel.security.auth.AuthException;
 import com.liferay.portal.kernel.security.auth.PrincipalException;
 import com.liferay.portal.kernel.service.LayoutLocalService;
 import com.liferay.portal.kernel.service.LayoutRevisionLocalService;
@@ -59,8 +54,6 @@ import com.liferay.staging.bar.web.internal.portlet.constants.StagingBarPortletK
 import com.liferay.staging.constants.StagingProcessesWebKeys;
 
 import java.io.IOException;
-
-import java.net.ConnectException;
 
 import java.util.List;
 
@@ -106,47 +99,6 @@ import org.osgi.service.component.annotations.Reference;
 	service = Portlet.class
 )
 public class StagingBarPortlet extends MVCPortlet {
-
-	public static String getLiveGroupURL(
-		Group group, Group liveGroup, Layout layout,
-		RenderRequest renderRequest) {
-
-		String remoteSiteURL = StringPool.BLANK;
-
-		if ((liveGroup != null) && group.isStagedRemotely()) {
-			try {
-				remoteSiteURL = StagingUtil.getRemoteSiteURL(
-					group, layout.isPrivateLayout());
-			}
-			catch (AuthException ae) {
-				_log.error(ae.getMessage());
-
-				SessionErrors.add(renderRequest, AuthException.class);
-			}
-			catch (SystemException se) {
-				Throwable cause = se.getCause();
-
-				if (!(cause instanceof ConnectException)) {
-					throw se;
-				}
-
-				if (_log.isWarnEnabled()) {
-					_log.warn(
-						"Unable to connect to remote live: " +
-							cause.getMessage());
-				}
-
-				SessionErrors.add(renderRequest, RemoteExportException.class);
-			}
-			catch (Exception e) {
-				_log.error(e, e);
-
-				SessionErrors.add(renderRequest, Exception.class);
-			}
-		}
-
-		return remoteSiteURL;
-	}
 
 	public void deleteLayoutRevision(
 			ActionRequest actionRequest, ActionResponse actionResponse)
@@ -629,9 +581,6 @@ public class StagingBarPortlet extends MVCPortlet {
 			_portal.updateImageId(layout, false, null, "iconImageId", 0, 0, 0);
 		}
 	}
-
-	private static final Log _log = LogFactoryUtil.getLog(
-		StagingBarPortlet.class);
 
 	private LayoutLocalService _layoutLocalService;
 	private LayoutRevisionLocalService _layoutRevisionLocalService;

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/init.jsp
@@ -76,7 +76,7 @@ page import="com.liferay.portal.kernel.workflow.WorkflowTask" %><%@
 page import="com.liferay.portal.util.PropsValues" %><%@
 page import="com.liferay.staging.bar.web.internal.display.context.LayoutBranchDisplayContext" %><%@
 page import="com.liferay.staging.bar.web.internal.display.context.LayoutSetBranchDisplayContext" %><%@
-page import="com.liferay.staging.bar.web.internal.portlet.StagingBarPortlet" %><%@
+page import="com.liferay.staging.bar.web.internal.display.context.StagingBarPortletDisplayContext" %><%@
 page import="com.liferay.staging.constants.StagingProcessesWebKeys" %>
 
 <%@ page import="java.util.ArrayList" %><%@
@@ -102,6 +102,7 @@ privateLayout = (boolean)renderRequest.getAttribute(WebKeys.PRIVATE_LAYOUT);
 
 LayoutBranchDisplayContext layoutBranchDisplayContext = new LayoutBranchDisplayContext(request);
 LayoutSetBranchDisplayContext layoutSetBranchDisplayContext = new LayoutSetBranchDisplayContext(request);
+StagingBarPortletDisplayContext stagingBarPortletDisplayContext = new StagingBarPortletDisplayContext(renderRequest);
 %>
 
 <%@ include file="/init-ext.jsp" %>

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/init.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/init.jsp
@@ -76,6 +76,7 @@ page import="com.liferay.portal.kernel.workflow.WorkflowTask" %><%@
 page import="com.liferay.portal.util.PropsValues" %><%@
 page import="com.liferay.staging.bar.web.internal.display.context.LayoutBranchDisplayContext" %><%@
 page import="com.liferay.staging.bar.web.internal.display.context.LayoutSetBranchDisplayContext" %><%@
+page import="com.liferay.staging.bar.web.internal.portlet.StagingBarPortlet" %><%@
 page import="com.liferay.staging.constants.StagingProcessesWebKeys" %>
 
 <%@ page import="java.util.ArrayList" %><%@

--- a/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/staging/staging-bar-web/src/main/resources/META-INF/resources/view.jsp
@@ -310,7 +310,7 @@ if (liveLayout != null) {
 
 		Liferay.on('allPortletsReady', function() {
 			A.io.request(
-				'<%= remoteSiteURL = StagingBarPortlet.getLiveGroupURL(group, liveGroup, layout, renderRequest) %>',
+				'<%= remoteSiteURL = stagingBarPortletDisplayContext.getLiveGroupURL(group, liveGroup, layout) %>',
 				{
 					on: {
 						failure: failureCallback,


### PR DESCRIPTION
/cc @knchau

Notes from Kim:
> https://issues.liferay.com/browse/LPS-94690
> 
> The issue is when the site is staging. At every page load of the Control Panel, the local server would send a request to the remote server. This can cause the site to hang because the request is sent in GroupServiceHttp.getGroupDisplayURL. The timeout can take 30 seconds. Issue can also be seen on page view with the button "Go to Remote Live". 
> 
> The fix involves an ajax call for fetching the URL after everything else is loaded and rendered. But while everything is rendering, the Control Panel will contain a spinner until everything is completely loaded. Whereas the button will also be loaded after page view load. 
> 
> Within the ajax call, it would check for a remote connection and return the live URL. If the remote connection is severed, I would add its respective SessionError. Upon connection failure, it would enter failureCallback. This function displays the tooltip error. If there is no remote connection (i.e. Staging Configuration is set to Local Live) and you're on the live page, the session error would be empty and the element link would be null so it would apply the appropriate attributes.
> 
> This fix won't affect the general performance because the ajax call is done after everything else is rendered.