### PR TITLE
LPS-121886 Migrate v2 usages in layout/layout-set-prototype-web

### DIFF
--- a/modules/apps/layout/layout-set-prototype-web/src/main/resources/META-INF/resources/js/LayoutSetManagementToolbarPropsTransformer.js
+++ b/modules/apps/layout/layout-set-prototype-web/src/main/resources/META-INF/resources/js/LayoutSetManagementToolbarPropsTransformer.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) 2000-present Liferay, Inc. All rights reserved.
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ */
+
+export default function propsTransformer({portletNamespace, ...otherProps}) {
+	return {
+		...otherProps,
+		onActionButtonClick(event, {item}) {
+			const action = item.data?.action;
+
+			if (action === 'deleteLayoutSetPrototypes') {
+				if (
+					confirm(
+						Liferay.Language.get(
+							'are-you-sure-you-want-to-delete-this'
+						)
+					)
+				) {
+					const form = document.getElementById(
+						`${portletNamespace}fm`
+					);
+
+					if (form) {
+						submitForm(form);
+					}
+				}
+			}
+		},
+	};
+}

--- a/modules/apps/layout/layout-set-prototype-web/src/main/resources/META-INF/resources/view.jsp
+++ b/modules/apps/layout/layout-set-prototype-web/src/main/resources/META-INF/resources/view.jsp
@@ -20,7 +20,7 @@
 
 <liferay-ui:error exception="<%= RequiredLayoutSetPrototypeException.class %>" message="you-cannot-delete-site-templates-that-are-used-by-a-site" />
 
-<clay:management-toolbar-v2
+<clay:management-toolbar
 	actionDropdownItems="<%= layoutSetPrototypeDisplayContext.getActionDropdownItems() %>"
 	clearResultsURL="<%= layoutSetPrototypeDisplayContext.getClearResultsURL() %>"
 	componentId="layoutSetPrototypeWebManagementToolbar"
@@ -28,6 +28,7 @@
 	filterDropdownItems="<%= layoutSetPrototypeDisplayContext.getFilterDropdownItems() %>"
 	infoPanelId="infoPanelId"
 	itemsTotal="<%= layoutSetPrototypeDisplayContext.getTotalItems() %>"
+	propsTransformer="js/LayoutSetManagementToolbarPropsTransformer"
 	searchActionURL="<%= layoutSetPrototypeDisplayContext.getSearchActionURL() %>"
 	searchContainerId="layoutSetPrototype"
 	searchFormName="searchFm"
@@ -187,31 +188,3 @@
 		/>
 	</liferay-ui:search-container>
 </aui:form>
-
-<aui:script sandbox="<%= true %>">
-	var deleteLayoutSetPrototypes = function () {
-		if (
-			confirm(
-				'<liferay-ui:message key="are-you-sure-you-want-to-delete-this" />'
-			)
-		) {
-			submitForm(document.querySelector('#<portlet:namespace />fm'));
-		}
-	};
-
-	var ACTIONS = {
-		deleteLayoutSetPrototypes: deleteLayoutSetPrototypes,
-	};
-
-	Liferay.componentReady('layoutSetPrototypeWebManagementToolbar').then(
-		(managementToolbar) => {
-			managementToolbar.on('actionItemClicked', (event) => {
-				var itemData = event.data.item.data;
-
-				if (itemData && itemData.action && ACTIONS[itemData.action]) {
-					ACTIONS[itemData.action]();
-				}
-			});
-		}
-	);
-</aui:script>


### PR DESCRIPTION
The <clay:management-toolbar-v2 /> tag has been replaced with the
<clay:management-toolbar /> tag (which uses clay v3).

Adding, sorting and deleting Site Templates should work as expected.

![](https://user-images.githubusercontent.com/5572/110000453-96a24680-7d13-11eb-8dc6-e0824e17b93f.gif)

**Test plan**:
- From the global menu, select the **Control Panel** tab
- Navigate to **Site Templates**
- From the management toolbar, make sure you can create a Site Template
- From the management toolbar, make sure you can delete a Site Template
- From the management toolbar, make sure you can sort Site Templates