### PR TITLE
master | LPS-126729

### DIFF
--- a/portal-impl/src/com/liferay/portal/servlet/TunnelServlet.java
+++ b/portal-impl/src/com/liferay/portal/servlet/TunnelServlet.java
@@ -14,6 +14,8 @@
 
 package com.liferay.portal.servlet;
 
+import com.liferay.exportimport.kernel.exception.MissingReferenceException;
+import com.liferay.exportimport.kernel.lar.MissingReferences;
 import com.liferay.portal.kernel.exception.PortalException;
 import com.liferay.portal.kernel.exception.SystemException;
 import com.liferay.portal.kernel.log.Log;
@@ -112,7 +114,17 @@ public class TunnelServlet extends HttpServlet {
 			if (throwable != null) {
 				Class<?> clazz = throwable.getClass();
 
-				if (throwable instanceof PortalException) {
+				if (throwable instanceof MissingReferenceException) {
+					MissingReferenceException missingReferenceException =
+						(MissingReferenceException)throwable;
+
+					MissingReferences missingReferences =
+						missingReferenceException.getMissingReferences();
+
+					returnObject = new MissingReferenceException(
+						missingReferences);
+				}
+				else if (throwable instanceof PortalException) {
 					returnObject = new PortalException(
 						"Invocation failed due to " + clazz.getName());
 				}


### PR DESCRIPTION
Hi @moltam89 ,

I talked about this ticket with Zsigmond Rab and he asked me that I send you this PR. You have more context about the ticket in Jira https://issues.liferay.com/browse/LPS-126729.

This modification tries to solve a functionality loss that we have in 7.3 when a reference error happens in a staging publication.

In 7.2 the error message showed info about the asset affected but in 7.3 we only show a general error and the user cannot know what the problematic asset is. 

The change that produces this loss was made in LPS-119049, which improves the platform security by restricting the information shown in error messages. I think that this change that I propose in this PR respects the security idea of the change LPS-119049, because no information about the error stack is shown, only business info.

If you have any doubt about the ticket, please, let me know.

Regards,

David Tello